### PR TITLE
Adds easter egg config option for testing

### DIFF
--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -6,16 +6,20 @@ import { Logger } from '../../lib/Logger';
 import { BitbucketClient } from '../../bitbucket/BitbucketClient';
 import { AccountService } from '../../lib/AccountService';
 import { permissionService } from '../../lib/PermissionService';
+import { Config } from '../../types';
 
 const landKidTag = process.env['LANDKID_TAG'] || 'Unknown';
 
-export function apiRoutes(runner: Runner, client: BitbucketClient) {
+export function apiRoutes(runner: Runner, client: BitbucketClient, config: Config) {
   const router = express();
+  const easterEggText = config.easterEgg || 'There is no cow level';
 
   router.get(
     '/meta',
     wrap(async (req, res) => {
-      res.header('Access-Control-Allow-Origin', '*').json({ meta: { 'tag-version': landKidTag }, isNew: true });
+      res
+        .header('Access-Control-Allow-Origin', '*')
+        .json({ meta: { 'tag-version': landKidTag, easterEgg: easterEggText }, isNew: true });
     }),
   );
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -29,7 +29,7 @@ export async function routes(server: express.Application, client: BitbucketClien
   router.get('/ac', (req, res) => {
     res.header('Access-Control-Allow-Origin', '*').json(bitbucketAddonDescriptor);
   });
-  router.use('/api', apiRoutes(runner, client));
+  router.use('/api', apiRoutes(runner, client, config));
   router.use('/auth', authRoutes());
   router.use('/bitbucket', bitbucketRoutes(runner, client));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type Config = {
   prSettings: PullRequestSettings;
   deployment: DeploymentConfig;
   sequelize?: any;
+  easterEgg?: any;
 };
 
 export type RunnerState = {


### PR DESCRIPTION
Adds a config option that is reflected on the `api/meta` endpoint.

This is useful when doing deployment tests and you need to be able to know if things are changing or not.