### PR TITLE
Add status name to build statuses API response

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -98,6 +98,7 @@ export class BitbucketAPI {
     return allBuildStatuses
       .filter(buildStatus => !buildStatus.name.match(/Pipeline #.+? for landkid/))
       .map(status => ({
+        name: status.name,
         state: status.state,
         createdOn: new Date(status.created_on),
         url: status.url,

--- a/src/bitbucket/types.d.ts
+++ b/src/bitbucket/types.d.ts
@@ -78,6 +78,7 @@ declare namespace BB {
   type BuildState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS' | 'STOPPED' | 'DEFAULT' | 'PENDING';
 
   type BuildStatus = {
+    name: string;
     state: BuildState;
     createdOn: Date;
     url: string;


### PR DESCRIPTION
This takes a specific change from https://github.com/atlassian/landkid/pull/44 but branched off master before the parallel builds work so that we can deploy only this change.