### PR TITLE
Check if running builds have any failed dependencies before adding them as a dep

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -19,8 +19,6 @@ import { permissionService } from './PermissionService';
 // const MAX_WAITING_TIME_FOR_PR_MS = 2 * 24 * 60 * 60 * 1000; // 2 days - max time build can "land-when able"
 
 export class Runner {
-  maxConcurrentBuilds: number;
-
   constructor(
     public queue: LandRequestQueue,
     private history: LandRequestHistory,
@@ -36,10 +34,12 @@ export class Runner {
     setInterval(() => {
       this.next();
     }, 15 * 1000); // 15s
-
-    this.maxConcurrentBuilds =
-      config.maxConcurrentBuilds && config.maxConcurrentBuilds > 0 ? config.maxConcurrentBuilds : 1;
   }
+
+  getMaxConcurrentBuilds = () =>
+    this.config.maxConcurrentBuilds && this.config.maxConcurrentBuilds > 0
+      ? this.config.maxConcurrentBuilds
+      : 1;
 
   getQueue = async () => {
     return this.queue.getQueue();
@@ -54,7 +54,7 @@ export class Runner {
     const runningTargetingSameBranch = running.filter(
       build => build.request.pullRequest.targetBranch === landRequest.pullRequest.targetBranch,
     );
-    if (runningTargetingSameBranch.length >= this.maxConcurrentBuilds) return false;
+    if (runningTargetingSameBranch.length >= this.getMaxConcurrentBuilds()) return false;
 
     const triggererUserMode = await permissionService.getPermissionForUser(
       landRequest.triggererAaid,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -90,8 +90,6 @@ export class Runner {
         dependencies.push(queueItem);
     }
 
-    // const dependencies = runningTargetingSameBranch.filter(async queueItem => (await queueItem.request.getFailedDependencies()).length === 0);
-
     Logger.info('Moving from queued to running', { landRequest: landRequest.get() });
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -19,12 +19,13 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     wrap(async (req, res) => {
       const install = await runner.getInstallationIfExists();
       const isInstalled = !!install;
+      const { customChecks, ...prSettings } = config.prSettings;
       res.header('Access-Control-Allow-Origin', '*').json({
         meta: {
           'tag-version': landKidTag,
           easterEgg: easterEggText,
           targetRepo: config.repoConfig.repoName,
-          prSettings: config.prSettings,
+          prSettings,
           maxConcurrentBuilds: runner.getMaxConcurrentBuilds(),
         },
         isInstalled,

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -25,7 +25,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
           easterEgg: easterEggText,
           targetRepo: config.repoConfig.repoName,
           prSettings: config.prSettings,
-          maxConcurrentBuilds: runner.maxConcurrentBuilds,
+          maxConcurrentBuilds: runner.getMaxConcurrentBuilds(),
         },
         isInstalled,
       });


### PR DESCRIPTION
I think this might fix the maxConcurrentBuilds issue as well