### PR TITLE
Improved Logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@atlaskit/pagination": "^8.0.5",
+    "@types/micromatch": "^4.0.1",
     "atlassian-jwt": "^1.0.1",
     "axios": "^0.19.2",
     "body-parser": "^1.18.2",
@@ -82,6 +83,7 @@
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "express-winston": "^3.0.1",
+    "micromatch": "^4.0.2",
     "p-retry": "^2.0.0",
     "passport": "^0.4.0",
     "passport-oauth2": "^1.4.0",

--- a/src/auth/bitbucket.ts
+++ b/src/auth/bitbucket.ts
@@ -45,7 +45,10 @@ export function initializePassport(oAuthConfig: OAuthConfig) {
             displayName: userResponse.data.display_name,
           };
 
-          Logger.info('User logged in', { aaid: userInfo.aaid });
+          Logger.info('User logged in', {
+            namespace: 'auth:bitbucket',
+            aaid: userInfo.aaid,
+          });
         } catch (err) {
           return verified(err);
         }

--- a/src/bitbucket/BitbucketAuthenticator.ts
+++ b/src/bitbucket/BitbucketAuthenticator.ts
@@ -22,7 +22,7 @@ class BitbucketAuthenticator {
       },
       install.sharedSecret,
     );
-    Logger.info('Generated JWT');
+    Logger.info('Generated JWT', { namespace: 'bitbucket:authenticator:getJWTAuthHeaders' });
     return {
       Authorization: `JWT ${token}`,
     };
@@ -35,10 +35,14 @@ class BitbucketAuthenticator {
     const install = await Installation.findOne<Installation>();
     let authHeaders: any;
     if (!install) {
-      Logger.info('no install, using basic auth');
+      Logger.info('no install, using basic auth', {
+        namespace: 'bitbucket:authenticator:getJWTAuthHeaders',
+      });
       authHeaders = this.getBasicAuthHeaders();
     } else {
-      Logger.info('found install, using JWT auth');
+      Logger.info('found install, using JWT auth', {
+        namespace: 'bitbucket:authenticator:getJWTAuthHeaders',
+      });
       authHeaders = this.getJWTAuthHeaders(request, install);
     }
 

--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -36,7 +36,8 @@ export class BitbucketClient {
     const { prSettings } = this.config;
     const errors: string[] = [];
 
-    Logger.info('isAllowedToLand()', {
+    Logger.info('Pull request approval checks', {
+      namespace: 'bitbucket:client:isAllowedToLand',
       pullRequestId,
       approvalChecks,
       requirements: prSettings,

--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -2,6 +2,7 @@ import { Config } from '../types';
 import { Logger } from '../lib/Logger';
 import { BitbucketPipelinesAPI } from './BitbucketPipelinesAPI';
 import { BitbucketAPI } from './BitbucketAPI';
+import { LandRequest } from '../db';
 
 // Given a list of approvals, will filter out users own approvals if settings don't allow that
 function getRealApprovals(approvals: Array<string>, creator: string, creatorCanApprove: boolean) {
@@ -78,16 +79,16 @@ export class BitbucketClient {
     };
   }
 
-  createLandBuild(commit: string, depCommits: string) {
-    return this.pipelines.createLandBuild(commit, depCommits);
+  createLandBuild(requestId: string, commit: string, depCommits: string) {
+    return this.pipelines.createLandBuild(requestId, commit, depCommits);
   }
 
   async stopLandBuild(buildId: number) {
     return await this.pipelines.stopLandBuild(buildId);
   }
 
-  async mergePullRequest(pullRequestId: number, targetBranch: string) {
-    return await this.bitbucket.mergePullRequest(pullRequestId, targetBranch);
+  async mergePullRequest(landRequest: LandRequest) {
+    return await this.bitbucket.mergePullRequest(landRequest);
   }
 
   processStatusWebhook(body: any): BB.BuildStatusEvent | null {

--- a/src/bitbucket/BitbucketPipelinesAPI.ts
+++ b/src/bitbucket/BitbucketPipelinesAPI.ts
@@ -50,9 +50,10 @@ export class BitbucketPipelinesAPI {
     };
   };
 
-  public createLandBuild = async (commit: string, depCommits: string) => {
+  public createLandBuild = async (requestId: string, commit: string, depCommits: string) => {
     Logger.info('Creating land build for commit', {
       namespace: 'bitbucket:pipelines:createLandBuild',
+      requestId,
       commit,
       depCommits,
     });
@@ -81,12 +82,14 @@ export class BitbucketPipelinesAPI {
     if (!resp.data.build_number || typeof resp.data.build_number !== 'number') {
       Logger.error('Response from creating build does not match the shape we expected', {
         namespace: 'bitbucket:pipelines:createLandBuild',
+        requestId,
         commit,
       });
       return null;
     }
     Logger.info('Created build', {
       namespace: 'bitbucket:pipelines:createLandBuild',
+      requestId,
       commit,
       buildNumber: resp.data.build_number,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,9 @@ import * as expressSession from 'express-session';
 import * as expressWinston from 'express-winston';
 import * as passport from 'passport';
 import * as session from 'express-session';
-
 import * as bodyParser from 'body-parser';
 
 import { initializeSequelize, MigrationService } from './db';
-
 import { BitbucketClient } from './bitbucket/BitbucketClient';
 import { config, hasConfig } from './lib/Config';
 import { LandRequestQueue } from './lib/Queue';
@@ -40,6 +38,7 @@ async function main() {
       meta: false,
       winstonInstance: Logger,
       colorize: process.env.NODE_ENV !== 'production',
+      level: 'http',
     }),
   );
   server.use(bodyParser.json());

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -11,8 +11,9 @@ const getConfig = (): Config | null => {
     let configValid = true;
 
     if (!config.deployment.oAuth.secret || !config.deployment.oAuth.key) {
-      Logger.error('deployment.oAuth.secret or deployment.oAuth.key are missing');
-      Logger.error('Did you forget to set an environment variable?');
+      Logger.error('deployment.oAuth.secret or deployment.oAuth.key are missing', {
+        namespace: 'lib:config:getConfig',
+      });
       configValid = false;
     }
 

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -3,16 +3,21 @@ import * as winston from 'winston';
 process.stdout.isTTY = true;
 
 const ProdLogger = winston.createLogger({
-  level: 'info',
+  level: 'http',
   format: winston.format.json(),
   transports: [new winston.transports.Console()],
 });
-const DevelopmentLogger = winston.createLogger({
-  level: 'info',
-  format: winston.format.combine(winston.format.colorize(), winston.format.simple()),
+
+const DevLogger = winston.createLogger({
+  level: 'verbose',
+  format: winston.format.combine(
+    winston.format.colorize(),
+    winston.format.printf(
+      ({ level, message, namespace, ...info }) =>
+        `${level}: ${namespace ? `[${namespace}] ` : ''}${message} ${JSON.stringify(info)}`,
+    ),
+  ),
   transports: [new winston.transports.Console()],
 });
 
-const LoggerToExport = process.env.NODE_ENV === 'production' ? ProdLogger : DevelopmentLogger;
-
-export const Logger = LoggerToExport;
+export const Logger = process.env.NODE_ENV === 'production' ? ProdLogger : DevLogger;

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -1,4 +1,5 @@
 import * as winston from 'winston';
+import { isMatch } from 'micromatch';
 
 process.stdout.isTTY = true;
 
@@ -11,6 +12,11 @@ const ProdLogger = winston.createLogger({
 const DevLogger = winston.createLogger({
   level: 'verbose',
   format: winston.format.combine(
+    winston.format(log =>
+      process.env.LOG_NAMESPACES && !isMatch(log.namespace || '', process.env.LOG_NAMESPACES)
+        ? false
+        : log,
+    )(),
     winston.format.colorize(),
     winston.format.printf(
       ({ level, message, namespace, ...info }) =>

--- a/src/lib/PermissionService.ts
+++ b/src/lib/PermissionService.ts
@@ -29,7 +29,6 @@ class PermissionService {
     mode: IPermissionMode,
     setter: ISessionUser,
   ): Promise<void> => {
-    Logger.info('Setting user permission', { aaid, mode, setter });
     await Permission.create({
       aaid,
       mode,

--- a/src/lib/PermissionService.ts
+++ b/src/lib/PermissionService.ts
@@ -13,7 +13,11 @@ class PermissionService {
 
     if (!permission) {
       const defaultMode: IPermissionMode = config.landkidAdmins.includes(aaid) ? 'admin' : 'read';
-      Logger.info('User does not exist, creating one', { defaultMode, aaid });
+      Logger.info('User does not exist, creating one', {
+        namespace: 'lib:permissions:getPermissionForUser',
+        defaultMode,
+        aaid,
+      });
       await Permission.create({
         aaid,
         mode: defaultMode,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -78,7 +78,7 @@ export class Runner {
     const targetBranchMatches = currentPrInfo.targetBranch === landRequest.pullRequest.targetBranch;
     const commitMatches = currentPrInfo.commit === landRequest.forCommit;
     if (!targetBranchMatches) {
-      Logger.verbose('Target branch changed between landing and running', {
+      Logger.info('Target branch changed between landing and running', {
         namespace: 'lib:runner:moveFromQueueToRunning',
         landRequestTargetBranch: landRequest.pullRequest.targetBranch,
         currentPrTargetBranch: currentPrInfo.targetBranch,
@@ -86,7 +86,7 @@ export class Runner {
       return landRequest.setStatus('aborted', 'Target branch changed between landing and running');
     }
     if (!commitMatches) {
-      Logger.verbose('Target branch changed between landing and running', {
+      Logger.info('Target branch changed between landing and running', {
         namespace: 'lib:runner:moveFromQueueToRunning',
         landRequestCommit: landRequest.forCommit,
         currentPrCommit: currentPrInfo.commit,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -125,7 +125,7 @@ export class Runner {
       dependsOn: dependsOnStr,
     });
 
-    const buildId = await this.client.createLandBuild(commit, depCommitsArrStr);
+    const buildId = await this.client.createLandBuild(landRequest.id, commit, depCommitsArrStr);
     if (!buildId) {
       Logger.verbose('Unable to create land build in Pipelines', {
         namespace: 'lib:runner:moveFromQueueToRunning',
@@ -179,10 +179,7 @@ export class Runner {
         pullRequestId,
         requestId: landRequest.id,
       });
-      await this.client.mergePullRequest(
-        pullRequestId,
-        landRequest.request.pullRequest.targetBranch,
-      );
+      await this.client.mergePullRequest(landRequest.request);
       Logger.info('Successfully merged PR', {
         namespace: 'lib:runner:moveFromAwaitingMerge',
         requestId: landRequest.id,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -54,7 +54,15 @@ export class Runner {
     const runningTargetingSameBranch = running.filter(
       build => build.request.pullRequest.targetBranch === landRequest.pullRequest.targetBranch,
     );
-    if (runningTargetingSameBranch.length >= this.getMaxConcurrentBuilds()) return false;
+    const maxConcurrentBuilds = this.getMaxConcurrentBuilds();
+    if (runningTargetingSameBranch.length >= maxConcurrentBuilds) {
+      Logger.verbose('No concurrent build slots left', {
+        namespace: 'lib:runner:moveFromQueueToRunning',
+        runningTargetingSameBranch,
+        maxConcurrentBuilds,
+      });
+      return false;
+    }
 
     const triggererUserMode = await permissionService.getPermissionForUser(
       landRequest.triggererAaid,
@@ -70,16 +78,28 @@ export class Runner {
     const targetBranchMatches = currentPrInfo.targetBranch === landRequest.pullRequest.targetBranch;
     const commitMatches = currentPrInfo.commit === landRequest.forCommit;
     if (!targetBranchMatches) {
+      Logger.verbose('Target branch changed between landing and running', {
+        namespace: 'lib:runner:moveFromQueueToRunning',
+        landRequestTargetBranch: landRequest.pullRequest.targetBranch,
+        currentPrTargetBranch: currentPrInfo.targetBranch,
+      });
       return landRequest.setStatus('aborted', 'Target branch changed between landing and running');
     }
     if (!commitMatches) {
+      Logger.verbose('Target branch changed between landing and running', {
+        namespace: 'lib:runner:moveFromQueueToRunning',
+        landRequestCommit: landRequest.forCommit,
+        currentPrCommit: currentPrInfo.commit,
+      });
       return landRequest.setStatus('aborted', 'PR commit changed between landing and running');
     }
 
     if (isAllowedToLand.errors.length > 0) {
       Logger.error('LandRequest no longer passes land checks', {
+        namespace: 'lib:runner:moveFromQueueToRunning',
         errors: isAllowedToLand.errors,
         landRequest,
+        requestId: landRequest.id,
       });
       return landRequest.setStatus('fail', 'Unable to land due to failed land checks');
     }
@@ -91,7 +111,6 @@ export class Runner {
       }
     }
 
-    Logger.info('Moving from queued to running', { landRequest: landRequest.get() });
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
     const dependsOnStr = dependencies.map(queueItem => queueItem.request.id).join(',');
@@ -99,8 +118,19 @@ export class Runner {
       dependencies.map(queueItem => queueItem.request.forCommit),
     );
 
+    Logger.info('Attempting to move from queued to running', {
+      namespace: 'lib:runner:moveFromQueueToRunning',
+      requestId: landRequest.id,
+      landRequest: landRequest.get(),
+      dependsOn: dependsOnStr,
+    });
+
     const buildId = await this.client.createLandBuild(commit, depCommitsArrStr);
     if (!buildId) {
+      Logger.verbose('Unable to create land build in Pipelines', {
+        namespace: 'lib:runner:moveFromQueueToRunning',
+        requestId: landRequest.id,
+      });
       return await landRequest.setStatus('fail', 'Unable to create land build in Pipelines');
     }
 
@@ -111,28 +141,32 @@ export class Runner {
         dependencies.map(queueItem => queueItem.request.pullRequestId).join(', ');
     }
 
-    Logger.info('LandRequest now running', {
-      dependsOnStr,
-      landRequest,
-      buildId,
-      depCommitsArrStr,
-    });
     await landRequest.setStatus('running', depPrsStr);
 
     // Todo: these should really be functions on landRequest
     landRequest.buildId = buildId;
     landRequest.dependsOn = dependsOnStr;
-    await landRequest.save();
+    const newLandRequest = await landRequest.save();
+
+    Logger.info('LandRequest now running', {
+      namespace: 'lib:runner:moveFromQueueToRunning',
+      requestId: newLandRequest.id,
+      landRequest: newLandRequest,
+      buildId,
+      depCommitsArrStr,
+    });
     return true;
   };
 
-  attemptToMoveFromAwaitingMerge = async (landRequest: LandRequestStatus) => {
+  moveFromAwaitingMerge = async (landRequest: LandRequestStatus) => {
     const dependencies = await landRequest.request.getDependencies();
 
     if (!dependencies.every(dep => dep.statuses[0].state === 'success')) {
       Logger.info('LandRequest is awaiting-merge but still waiting on dependencies', {
-        dependencies,
+        namespace: 'lib:runner:moveFromAwaitingMerge',
+        requestId: landRequest.id,
         landRequest,
+        dependencies,
       });
       return false; // did not move state, return false
     }
@@ -140,12 +174,20 @@ export class Runner {
     // Try to merge PR
     try {
       const pullRequestId = landRequest.request.pullRequestId;
-      Logger.info('Attempting merge pull request', { pullRequestId, landRequest });
+      Logger.verbose('Attempting merge pull request', {
+        namespace: 'lib:runner:moveFromAwaitingMerge',
+        pullRequestId,
+        requestId: landRequest.id,
+      });
       await this.client.mergePullRequest(
         pullRequestId,
         landRequest.request.pullRequest.targetBranch,
       );
-      Logger.info('Successfully merged PR', { pullRequestId });
+      Logger.info('Successfully merged PR', {
+        namespace: 'lib:runner:moveFromAwaitingMerge',
+        requestId: landRequest.id,
+        pullRequestId,
+      });
       return await landRequest.request.setStatus('success');
     } catch (err) {
       return await landRequest.request.setStatus('fail', 'Unable to merge pull request');
@@ -156,13 +198,21 @@ export class Runner {
   next = async () => {
     await withLock('Runner:next', async () => {
       const queue = await this.queue.getQueue();
-      Logger.info('Next() called', { queue });
+      Logger.info('Next() called', {
+        namespace: 'lib:runner:next',
+        queue,
+      });
 
       for (const landRequest of queue) {
         // Check for this _before_ looking at the state so that we don't have to wait until
         const failedDeps = await landRequest.request.getFailedDependencies();
         if (failedDeps.length !== 0) {
-          Logger.info('LandRequest failed due to failing dependency');
+          Logger.info('LandRequest failed due to failing dependency', {
+            namespace: 'lib:runner:next',
+            requestId: landRequest.requestId,
+            pullRequestId: landRequest.request.pullRequestId,
+            failedDeps,
+          });
           const failedPrIds = failedDeps.map(d => d.request.pullRequestId).join(', ');
           const failReason = `Failed due to failed dependency builds: ${failedPrIds}`;
           await landRequest.request.setStatus('fail', failReason);
@@ -172,7 +222,7 @@ export class Runner {
           return await landRequest.request.setStatus('queued');
         }
         if (landRequest.state === 'awaiting-merge') {
-          const didChangeState = await this.attemptToMoveFromAwaitingMerge(landRequest);
+          const didChangeState = await this.moveFromAwaitingMerge(landRequest);
           // if we moved, we need to exit early, otherwise, just keep checking the queue
           if (didChangeState) return this.next();
         } else if (landRequest.state === 'queued') {
@@ -183,7 +233,6 @@ export class Runner {
         }
         // otherwise, we must just be running, nothing to do here
       }
-      //
     });
   };
 
@@ -191,26 +240,47 @@ export class Runner {
   onStatusUpdate = async (statusEvent: BB.BuildStatusEvent) => {
     const running = await this.getRunning();
     if (!running.length) {
-      Logger.info('No builds running, status event is irrelevant', { statusEvent });
+      Logger.info('No builds running, status event is irrelevant', {
+        namespace: 'lib:runner:onStatusUpdate',
+        statusEvent,
+      });
       return;
     }
     for (const landRequest of running) {
       if (statusEvent.buildId !== landRequest.request.buildId) continue; // check next landRequest
       switch (statusEvent.buildStatus) {
         case 'SUCCESSFUL':
-          Logger.info('Moving landRequest to awaiting-merge state', { landRequest });
+          Logger.info('Moving landRequest to awaiting-merge state', {
+            namespace: 'lib:runner:onStatusUpdate',
+            requestId: landRequest.requestId,
+            pullRequestId: landRequest.request.pullRequestId,
+            landRequest,
+          });
           await landRequest.request.setStatus('awaiting-merge');
           return this.next();
         case 'FAILED':
-          Logger.info('Moving landRequest to failed state', { landRequest });
+          Logger.info('Moving landRequest to failed state', {
+            namespace: 'lib:runner:onStatusUpdate',
+            requestId: landRequest.requestId,
+            pullRequestId: landRequest.request.pullRequestId,
+            landRequest,
+          });
           await landRequest.request.setStatus('fail', 'Landkid build failed');
           return this.next();
         case 'STOPPED':
-          Logger.info('Moving landRequest to aborted state', { landRequest });
+          Logger.info('Moving landRequest to aborted state', {
+            namespace: 'lib:runner:onStatusUpdate',
+            requestId: landRequest.requestId,
+            pullRequestId: landRequest.request.pullRequestId,
+            landRequest,
+          });
           await landRequest.request.setStatus('aborted', 'Landkid pipelines build was stopped');
           return this.next();
         default:
-          Logger.info('Dont know what to do with build status, ignoring', { statusEvent });
+          Logger.info('Dont know what to do with build status, ignoring', {
+            namespace: 'lib:runner:onStatusUpdate',
+            statusEvent,
+          });
           break;
       }
     }
@@ -301,7 +371,6 @@ export class Runner {
   enqueue = async (landRequestOptions: LandRequestOptions): Promise<void> => {
     // TODO: Ensure no land request is pending for this PR
     if (await this.getPauseState()) return;
-
     const request = await this.createRequestFromOptions(landRequestOptions);
     await request.setStatus('queued');
   };
@@ -329,7 +398,10 @@ export class Runner {
 
       await request.setStatus('queued');
     }
-    Logger.info('Moving landRequests from waiting to queue', { requests });
+    Logger.info('Moving landRequests from waiting to queue', {
+      namespace: 'lib:runner:moveFromWaitingToQueued',
+      requests,
+    });
 
     this.next();
   };
@@ -343,7 +415,11 @@ export class Runner {
       'aborted',
       `Removed from queue by user "${displayName}`,
     );
-    Logger.info('Removing landRequest from queue', { landRequestStatus });
+    Logger.info('Removing landRequest from queue', {
+      namespace: 'lib:removeLandRequestFromQueue',
+      requestId: landRequestStatus.requestId,
+      landRequestStatus,
+    });
     return true;
   };
 
@@ -366,7 +442,9 @@ export class Runner {
   };
 
   checkWaitingLandRequests = async () => {
-    Logger.info('Checking for waiting landrequests ready to queue');
+    Logger.info('Checking for waiting landrequests ready to queue', {
+      namespace: 'lib:runner:checkWaitingLandRequests',
+    });
 
     for (let landRequest of await this.queue.getStatusesForWaitingRequests()) {
       const pullRequestId = landRequest.request.pullRequestId;
@@ -489,7 +567,7 @@ export class Runner {
   };
 
   clearHistory = async () => {
-    Logger.info('Clearing LandRequest History');
+    Logger.info('Clearing LandRequest History', { namespace: 'lib:runner:clearHistory' });
     await LandRequestStatus.truncate();
     await LandRequest.truncate();
     await PullRequest.truncate();

--- a/src/lib/utils/locker.ts
+++ b/src/lib/utils/locker.ts
@@ -15,7 +15,10 @@ export const withLock = async <T>(resource: string, fn: () => Promise<T>) => {
   try {
     result = await fn();
   } catch (err) {
-    Logger.error(`Error failed while in lock for "${resource}"`, { err });
+    Logger.error(`Error failed while in lock for "${resource}"`, {
+      namespace: 'lib:utils:locker:withLock',
+      err,
+    });
   }
   await lock.unlock();
   return result!;

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -17,6 +17,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
   router.get(
     '/meta',
     wrap(async (req, res) => {
+      Logger.verbose('Requesting meta information', { namespace: 'routes:api:meta' });
       const install = await runner.getInstallationIfExists();
       const isInstalled = !!install;
       const { customChecks, ...prSettings } = config.prSettings;
@@ -38,7 +39,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('read'),
     wrap(async (req, res) => {
       const state = await runner.getState(req.user!);
-      Logger.info('Requesting current state');
+      Logger.info('Requesting current state', { namespace: 'routes:api:current-state' });
       res.header('Access-Control-Allow-Origin', '*').json(state);
     }),
   );
@@ -49,7 +50,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     wrap(async (req, res) => {
       const page = parseInt(req.query.page || '0', 10);
       const history = await runner.getHistory(page);
-      Logger.info('Requesting current history');
+      Logger.info('Requesting history', { namespace: 'routes:api:history', page });
       res.header('Access-Control-Allow-Origin', '*').json(history);
     }),
   );
@@ -58,7 +59,9 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/user/:aaid',
     requireAuth('read'),
     wrap(async (req, res) => {
-      res.json(await AccountService.get(client).getAccountInfo(req.params.aaid));
+      const aaid = req.params.aaid;
+      Logger.verbose('Requesting user', { namespace: 'routes:api:user', aaid });
+      res.json(await AccountService.get(client).getAccountInfo(aaid));
     }),
   );
 
@@ -66,12 +69,13 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/permission/:aaid',
     requireAuth('admin'),
     wrap(async (req, res) => {
-      const userAaid = req.params.aaid;
+      const aaid = req.params.aaid;
       const mode = req.body.mode;
+      Logger.verbose('Setting user permission', { namespace: 'routes:api:permission', aaid, mode });
       if (['read', 'land', 'admin'].indexOf(mode) === -1) {
         res.status(400).json({ error: 'Invalid permission mode' });
       }
-      res.json(await permissionService.setPermissionForUser(userAaid, mode, req.user!));
+      res.json(await permissionService.setPermissionForUser(aaid, mode, req.user!));
     }),
   );
 
@@ -79,13 +83,14 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/note/:aaid',
     requireAuth('admin'),
     wrap(async (req, res) => {
-      const userAaid = req.params.aaid;
+      const aaid = req.params.aaid;
       const note = req.body.note;
+      Logger.verbose('Setting user note', { namespace: 'routes:api:note', aaid, note });
       if (!note) {
         res.status(400).json({ error: 'Note can not be empty' });
       }
-      await permissionService.setNoteForUser(userAaid, note, req.user!);
-      res.json({ message: `Added note to user ${userAaid}` });
+      await permissionService.setNoteForUser(aaid, note, req.user!);
+      res.json({ message: `Added note to user ${aaid}` });
     }),
   );
 
@@ -93,9 +98,10 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/note/:aaid',
     requireAuth('admin'),
     wrap(async (req, res) => {
-      const userAaid = req.params.aaid;
-      await permissionService.removeUserNote(userAaid);
-      res.json({ message: `Removed note from user ${userAaid}` });
+      const aaid = req.params.aaid;
+      Logger.verbose('Removing user note', { namespace: 'routes:api:note', aaid });
+      await permissionService.removeUserNote(aaid);
+      res.json({ message: `Removed note from user ${aaid}` });
     }),
   );
 
@@ -107,6 +113,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       if (req && req.body && req.body.reason) {
         pausedReason = String(req.body.reason);
       }
+      Logger.verbose('Pausing', { namespace: 'routes:api:pause', pausedReason });
       runner.pause(pausedReason, req.user!);
       res.json({ paused: true, pausedReason });
     }),
@@ -116,6 +123,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/unpause',
     requireAuth('admin'),
     wrap(async (req, res) => {
+      Logger.verbose('Unpausing', { namespace: 'routes:api:unpause' });
       await runner.unpause();
       res.json({ paused: false });
     }),
@@ -128,6 +136,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/next',
     requireAuth('admin'),
     wrap(async (req, res) => {
+      Logger.verbose('Calling next', { namespace: 'routes:api:next' });
       await runner.next();
       res.json({ message: 'Called next()' });
     }),
@@ -137,6 +146,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/uninstall',
     requireAuth('admin'),
     wrap(async (req, res) => {
+      Logger.verbose('Uninstalling', { namespace: 'routes:api:uninstall' });
       await runner.deleteInstallation();
       res.json({ message: 'Installation deleted' });
     }),
@@ -147,6 +157,10 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       const requestId = req.params.id;
+      Logger.verbose('Removing landrequest from queue', {
+        namespace: 'routes:api:remove',
+        requestId,
+      });
       const success = await runner.removeLandRequestFromQueue(requestId, req.user!);
       if (success) {
         res.json({ message: 'Request removed from queue' });
@@ -161,6 +175,10 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       const requestId = req.params.id;
+      Logger.verbose('Cancelling running landrequest', {
+        namespace: 'routes:api:cancel',
+        requestId,
+      });
       const success = await runner.cancelRunningBuild(requestId, req.user!);
       if (success) {
         res.json({ message: 'Running build cancelled' });
@@ -180,6 +198,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
         message = String(req.body.message);
         type = String(req.body.type);
       }
+      Logger.verbose('Setting message', { namespace: 'routes:api:message', message, type });
       if (!message) {
         res.status(400).json({ error: 'Cannot send an empty message' });
       }
@@ -196,6 +215,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/remove-message',
     requireAuth('admin'),
     wrap(async (req, res) => {
+      Logger.verbose('Removing message', { namespace: 'routes:api:remove-message' });
       await runner.removeBannerMessage();
       res.json({ removed: true });
     }),
@@ -206,6 +226,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('land'),
     wrap(async (req, res) => {
       const ids = req.query.ids.split(',');
+      Logger.verbose('Requesting landrequests', { namespace: 'routes:api:landrequests', ids });
       res.json({ statuses: await runner.getStatusesForLandRequests(ids) });
     }),
   );
@@ -232,6 +253,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/delete-history',
     requireAuth('admin'),
     wrap(async (req, res) => {
+      Logger.verbose('Deleting history', { namespace: 'routes:api:delete-history' });
       await runner.clearHistory();
       res.json({ response: 'You better be sure about this captain... Done!' });
     }),
@@ -242,6 +264,10 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       const requestId = req.params.id;
+      Logger.verbose('Moving landrequest to the top of the queue', {
+        namespace: 'routes:api:to-the-top',
+        requestId,
+      });
       const success = await runner.moveRequestToTopOfQueue(requestId, req.user!);
       if (success) {
         res.json({ message: 'Request moved to top of queue' });

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import * as passport from 'passport';
 import { permissionService } from '../../lib/PermissionService';
 import { wrap } from '../middleware';
+import { Logger } from '../../lib/Logger';
 
 export function authRoutes() {
   const router = express();
@@ -18,12 +19,11 @@ export function authRoutes() {
   router.get(
     '/whoami',
     wrap(async (req, res) => {
+      Logger.verbose('Requesting whoami', { namespace: 'routes:auth:whoami', user: req.user });
       res.json({
         loggedIn: !!req.user,
         user: req.user,
-        permission: req.user
-          ? await permissionService.getPermissionForUser(req.user.aaid)
-          : 'read',
+        permission: req.user ? await permissionService.getPermissionForUser(req.user.aaid) : 'read',
       });
     }),
   );

--- a/src/routes/bitbucket/lifecycle/index.ts
+++ b/src/routes/bitbucket/lifecycle/index.ts
@@ -10,7 +10,7 @@ export function lifecycleRoutes(runner: Runner) {
   router.post(
     '/installed',
     wrap(async (req, res) => {
-      Logger.verbose('Requesting creation of installion entry', {
+      Logger.verbose('Requesting creation of installation entry', {
         namespace: 'routes:bitbucket:lifecycle:installed',
       });
       const install = await Installation.findOne<Installation>();
@@ -37,7 +37,9 @@ export function lifecycleRoutes(runner: Runner) {
         clientKey: req.body.clientKey,
         sharedSecret: req.body.sharedSecret,
       });
-      Logger.info('Created installed entry', { namespace: 'routes:bitbucket:lifecycle:installed' });
+      Logger.info('Created installation entry', {
+        namespace: 'routes:bitbucket:lifecycle:installed',
+      });
 
       res.send('OK');
     }),

--- a/src/routes/bitbucket/lifecycle/index.ts
+++ b/src/routes/bitbucket/lifecycle/index.ts
@@ -10,11 +10,16 @@ export function lifecycleRoutes(runner: Runner) {
   router.post(
     '/installed',
     wrap(async (req, res) => {
+      Logger.verbose('Requesting creation of installion entry', {
+        namespace: 'routes:bitbucket:lifecycle:installed',
+      });
       const install = await Installation.findOne<Installation>();
       if (install) {
-        Logger.error('Attempted to install over and existing installation');
+        Logger.error('Attempted to install over an existing installation', {
+          namespace: 'routes:bitbucket:lifecyle:installed',
+        });
         return res.status(400).json({
-          error: 'Attempted to install over and existing installation',
+          error: 'Attempted to install over an existing installation',
         });
       }
 
@@ -32,6 +37,7 @@ export function lifecycleRoutes(runner: Runner) {
         clientKey: req.body.clientKey,
         sharedSecret: req.body.sharedSecret,
       });
+      Logger.info('Created installed entry', { namespace: 'routes:bitbucket:lifecycle:installed' });
 
       res.send('OK');
     }),
@@ -42,9 +48,7 @@ export function lifecycleRoutes(runner: Runner) {
     authenticateIncomingBBCall,
     wrap(async (req, res) => {
       await Installation.destroy({
-        where: {
-          id: 'the-one-and-only',
-        },
+        where: { id: 'the-one-and-only' },
       });
 
       const [queued, waiting] = await Promise.all([

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -98,7 +98,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
 
       await runner.enqueue(landRequest);
       Logger.info('Pull request landed', {
-        namespace: 'routes:proxy:bitbucket:land',
+        namespace: 'routes:bitbucket:proxy:land',
         pullRequestId: prId,
         landRequest,
       });
@@ -135,7 +135,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
       };
       await runner.addToWaitingToLand(landRequest);
       Logger.info('Pull request will land when able', {
-        namespace: 'routes:proxy:bitbucket:land-when-able',
+        namespace: 'routes:bitbucket:proxy:land-when-able',
         pullRequestId: prId,
         landRequest,
       });

--- a/src/routes/bitbucket/webhook/index.ts
+++ b/src/routes/bitbucket/webhook/index.ts
@@ -12,7 +12,7 @@ export function webhookRoutes(runner: Runner, client: BitbucketClient) {
   router.post(
     '/status-updated',
     wrap(async (req, res) => {
-      res.status(200).send({});
+      res.sendStatus(200);
       // status event will be null if we don't care about it
       const statusEvent = client.processStatusWebhook(req.body);
       if (!statusEvent) return;

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -24,7 +24,9 @@ export const permission = (userMode: IPermissionMode) => ({
 export const requireAuth = (mode: IPermissionMode = 'read'): express.RequestHandler =>
   wrap(async (req, res, next) => {
     if (!req.user) {
-      Logger.warn('Endpoint requires authentication');
+      Logger.warn('Endpoint requires authentication', {
+        namespace: 'routes:middleware:requireAuth',
+      });
       return res.status(401).json({
         error: 'This endpoint requires authentication',
       });
@@ -44,14 +46,18 @@ export const requireAuth = (mode: IPermissionMode = 'read'): express.RequestHand
 export const authenticateIncomingBBCall: express.RequestHandler = wrap(async (req, res, next) => {
   const install = await Installation.findOne<Installation>();
   if (!install) {
-    Logger.error('Addon has not been installed, can not be validated');
+    Logger.error('Addon has not been installed, can not be validated', {
+      namespace: 'routes:middleware:authenticateIncomingBBCall',
+    });
     return res.status(401).json({
       error: 'Addon has not been installed, can not be validated',
     });
   }
   let jwt: string | undefined = req.query.jwt || req.header('authorization');
   if (!jwt) {
-    Logger.error('Authenticated request requires a JWT token');
+    Logger.error('Authenticated request requires a JWT token', {
+      namespace: 'routes:middleware:authenticateIncomingBBCall',
+    });
     return res.status(401).json({
       error: 'Authenticated request requires a JWT token',
     });
@@ -64,7 +70,9 @@ export const authenticateIncomingBBCall: express.RequestHandler = wrap(async (re
   try {
     decoded = jwtTools.decode(jwt, install.sharedSecret);
   } catch (err) {
-    Logger.error('Could not validate JWT');
+    Logger.error('Could not validate JWT', {
+      namespace: 'routes:middleware:authenticateIncomingBBCall',
+    });
     return res.status(401).json({
       error: 'Could not validate JWT',
     });
@@ -79,7 +87,9 @@ export const authenticateIncomingBBCall: express.RequestHandler = wrap(async (re
   const expectedHash = jwtTools.createQueryStringHash(jwtTools.fromExpressRequest(req));
 
   if (expectedHash !== decoded.qsh) {
-    Logger.error('JWT token is valid but not for this request');
+    Logger.error('JWT token is valid but not for this request', {
+      namespace: 'routes:middleware:authenticateIncomingBBCall',
+    });
     return res.status(401).json({
       error: 'JWT token is valid but not for this request',
     });

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -24,7 +24,7 @@ export const permission = (userMode: IPermissionMode) => ({
 export const requireAuth = (mode: IPermissionMode = 'read'): express.RequestHandler =>
   wrap(async (req, res, next) => {
     if (!req.user) {
-      Logger.error('Endpoint requires authentication');
+      Logger.warn('Endpoint requires authentication');
       return res.status(401).json({
         error: 'This endpoint requires authentication',
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/braces@*":
+  version "3.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
+  integrity sha1-faHA1E/xx+tmCjbsB46mG6frQss=
+
 "@types/bson@*":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.0.1.tgz#2bfc80819e7055b76d5496d5344ed23e5d12bbb2"
@@ -274,6 +279,13 @@
 "@types/lodash@*":
   version "4.14.118"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+
+"@types/micromatch@^4.0.1":
+  version "4.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
+  integrity sha1-k4FEndZZ/Dgj/SpBkM6syYUIO8c=
+  dependencies:
+    "@types/braces" "*"
 
 "@types/mime@*":
   version "2.0.0"
@@ -1841,6 +1853,13 @@ braces@^2.3.0, braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha1-NFThpGLujVmeI23zNs2epPiv4Qc=
+  dependencies:
+    fill-range "^7.0.1"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -3882,6 +3901,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha1-GRmmp8df44ssfHflGYU12prN2kA=
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
@@ -5093,6 +5119,11 @@ is-number@^3.0.0:
 is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=
 
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
@@ -6352,6 +6383,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -7405,6 +7444,11 @@ pgpass@1.x:
   resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
   dependencies:
     split "^1.0.0"
+
+picomatch@^2.0.5:
+  version "2.2.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha1-IbrIiLbthgH4Mc54FuM1vHefCko=
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -9359,6 +9403,13 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=
+  dependencies:
+    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Added new `verbose` logging level for local development.

Added namespaces to all logs, which can be filtered with:
- locally with the `LOG_NAMESPACES` env var
  - `LOG_NAMESPACES=routes:api:* yarn dev` will only shows logs from `src/routes/api`
- in splunk with `namespace` variable
  - `namespace=routes:api:*`

Added basic indicators to as many logs as possible: `requestId`, `pullRequestId`, `buildId`, and similar. Allows these variables to be used in Splunk to follow the flow of requests, pull requests, builds, etc.