### PR TITLE
Add status-transition lock to checkWaitingLandRequests

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -222,7 +222,7 @@ export class Runner {
 
   // Next must always return early if ever doing a single state transition
   next = async () => {
-    await withLock('Runner:next', async (lockId: Date) => {
+    await withLock('status-transition', async (lockId: Date) => {
       const queue = await this.queue.getQueue();
       Logger.info('Next() called', {
         namespace: 'lib:runner:next',
@@ -415,6 +415,7 @@ export class Runner {
     this.checkWaitingLandRequests();
   };
 
+  // TODO: CHECK FOR LOCK
   moveFromWaitingToQueued = async (pullRequestId: number) => {
     if (await this.getPauseState()) return;
 
@@ -472,38 +473,41 @@ export class Runner {
     return true;
   };
 
+  // TODO: ADD LOCK
   checkWaitingLandRequests = async () => {
-    Logger.info('Checking for waiting landrequests ready to queue', {
-      namespace: 'lib:runner:checkWaitingLandRequests',
-    });
+    await withLock('status-transition', async () => {
+      Logger.info('Checking for waiting landrequests ready to queue', {
+        namespace: 'lib:runner:checkWaitingLandRequests',
+      });
 
-    for (let landRequestStatus of await this.queue.getStatusesForWaitingRequests()) {
-      const landRequest = landRequestStatus.request;
-      const pullRequestId = landRequest.pullRequestId;
-      const triggererUserMode = await permissionService.getPermissionForUser(
-        landRequest.triggererAaid,
-      );
-      const isAllowedToLand = await this.client.isAllowedToLand(pullRequestId, triggererUserMode);
-
-      if (isAllowedToLand.errors.length === 0) {
-        const queue = await this.getQueue();
-        const existingBuild = queue.find(
-          q => q.request.pullRequestId === landRequest.pullRequestId,
+      for (let landRequestStatus of await this.queue.getStatusesForWaitingRequests()) {
+        const landRequest = landRequestStatus.request;
+        const pullRequestId = landRequest.pullRequestId;
+        const triggererUserMode = await permissionService.getPermissionForUser(
+          landRequest.triggererAaid,
         );
-        if (existingBuild) {
-          Logger.warn('Already has existing Land build', {
-            pullRequestId,
-            landRequestId: landRequest.id,
-            landRequestStatus,
-            existingBuild,
-            namespace: 'lib:runner:checkWaitingLandRequests',
-          });
-          await landRequest.setStatus('aborted', 'Already has existing Land build');
-          continue;
+        const isAllowedToLand = await this.client.isAllowedToLand(pullRequestId, triggererUserMode);
+
+        if (isAllowedToLand.errors.length === 0) {
+          const queue = await this.getQueue();
+          const existingBuild = queue.find(
+            q => q.request.pullRequestId === landRequest.pullRequestId,
+          );
+          if (existingBuild) {
+            Logger.warn('Already has existing Land build', {
+              pullRequestId,
+              landRequestId: landRequest.id,
+              landRequestStatus,
+              existingBuild,
+              namespace: 'lib:runner:checkWaitingLandRequests',
+            });
+            await landRequest.setStatus('aborted', 'Already has existing Land build');
+            continue;
+          }
+          await this.moveFromWaitingToQueued(pullRequestId);
         }
-        await this.moveFromWaitingToQueued(pullRequestId);
       }
-    }
+    });
   };
 
   getStatusesForLandRequests = async (

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -415,7 +415,6 @@ export class Runner {
     this.checkWaitingLandRequests();
   };
 
-  // TODO: CHECK FOR LOCK
   moveFromWaitingToQueued = async (pullRequestId: number) => {
     if (await this.getPauseState()) return;
 
@@ -473,7 +472,6 @@ export class Runner {
     return true;
   };
 
-  // TODO: ADD LOCK
   checkWaitingLandRequests = async () => {
     await withLock('status-transition', async () => {
       Logger.info('Checking for waiting landrequests ready to queue', {


### PR DESCRIPTION
`checkWaitingLandRequests` has a similar functionality to `next`, it iterates over a list of requests and performs status transition actions. We lock `next` so there are no conflicts, we should also do that here.

[see investigation here](https://hello.atlassian.net/wiki/spaces/~904291390/pages/767240910/Weirdness)