### PR TITLE
AFP-2125 Landkid Blame

### DIFF
--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -111,4 +111,8 @@ export class BitbucketClient {
 
     return repo.uuid;
   }
+
+  async getUser(aaid: string): Promise<ISessionUser> {
+    return this.bitbucket.getUser(aaid);
+  }
 }

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -469,7 +469,7 @@ export class Runner {
 
     await landRequestStatus.request.setStatus(
       'queued',
-      `moved to the top of the queue by user ${user.aaid}`,
+      `moved to the top of the queue by user ${user.displayName || user.aaid}`,
       topDate,
     );
     return true;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -214,8 +214,7 @@ export class Runner {
         pullRequestId,
         lockId,
       });
-      const user = await this.client.getUser(landRequest.triggererAaid);
-      return landRequest.setStatus('success', `Landed by ${user.displayName || user.aaid}`);
+      return landRequest.setStatus('success');
     } catch (err) {
       return landRequest.setStatus('fail', 'Unable to merge pull request');
     }
@@ -250,7 +249,7 @@ export class Runner {
           await landRequest.update({ dependsOn: null });
           await this.client.stopLandBuild(landRequest.buildId, lockId);
           const user = await this.client.getUser(landRequest.triggererAaid);
-          return landRequest.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
+          return landRequest.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
         }
         if (landRequestStatus.state === 'awaiting-merge') {
           const didChangeState = await this.moveFromAwaitingMerge(landRequestStatus, lockId);
@@ -327,7 +326,7 @@ export class Runner {
 
     await landRequestStatus.request.setStatus(
       'aborted',
-      `Cancelled by user "${user.displayName || user.aaid}"`,
+      `Cancelled by user ${user.displayName || user.aaid}`,
     );
     if (landRequestStatus.request.buildId) {
       return this.client.stopLandBuild(landRequestStatus.request.buildId);
@@ -405,7 +404,7 @@ export class Runner {
     if (await this.getPauseState()) return;
     const request = await this.createRequestFromOptions(landRequestOptions);
     const user = await this.client.getUser(request.triggererAaid);
-    return request.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
+    return request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
   };
 
   addToWaitingToLand = async (landRequestOptions: LandRequestOptions) => {
@@ -430,7 +429,7 @@ export class Runner {
       if (status && status.state !== 'will-queue-when-ready') continue;
 
       const user = await this.client.getUser(request.triggererAaid);
-      await request.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
+      await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
     }
     Logger.info('Moving landRequests from waiting to queue', {
       namespace: 'lib:runner:moveFromWaitingToQueued',
@@ -447,7 +446,7 @@ export class Runner {
     const displayName = user.displayName || user.aaid;
     await landRequestStatus.request.setStatus(
       'aborted',
-      `Removed from queue by user "${displayName}"`,
+      `Removed from queue by user ${displayName}`,
     );
     Logger.info('Removing landRequest from queue', {
       namespace: 'lib:removeLandRequestFromQueue',
@@ -469,7 +468,7 @@ export class Runner {
 
     await landRequestStatus.request.setStatus(
       'queued',
-      `moved to the top of the queue by user ${user.displayName || user.aaid}`,
+      `Moved to the top of the queue by user ${user.displayName || user.aaid}`,
       topDate,
     );
     return true;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -214,7 +214,8 @@ export class Runner {
         pullRequestId,
         lockId,
       });
-      return landRequest.setStatus('success');
+      const user = await this.client.getUser(landRequest.triggererAaid);
+      return landRequest.setStatus('success', `Landed by ${user.displayName || user.aaid}`);
     } catch (err) {
       return landRequest.setStatus('fail', 'Unable to merge pull request');
     }
@@ -248,8 +249,8 @@ export class Runner {
           await landRequest.setStatus('fail', failReason);
           await landRequest.update({ dependsOn: null });
           await this.client.stopLandBuild(landRequest.buildId, lockId);
-          // await landRequest.request.save();
-          return landRequest.setStatus('queued');
+          const user = await this.client.getUser(landRequest.triggererAaid);
+          return landRequest.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
         }
         if (landRequestStatus.state === 'awaiting-merge') {
           const didChangeState = await this.moveFromAwaitingMerge(landRequestStatus, lockId);
@@ -326,7 +327,7 @@ export class Runner {
 
     await landRequestStatus.request.setStatus(
       'aborted',
-      `Cancelled by user "${user.aaid}" (${user.displayName})`,
+      `Cancelled by user "${user.displayName || user.aaid}"`,
     );
     if (landRequestStatus.request.buildId) {
       return this.client.stopLandBuild(landRequestStatus.request.buildId);
@@ -403,7 +404,8 @@ export class Runner {
     // TODO: Ensure no land request is pending for this PR
     if (await this.getPauseState()) return;
     const request = await this.createRequestFromOptions(landRequestOptions);
-    await request.setStatus('queued');
+    const user = await this.client.getUser(request.triggererAaid);
+    return request.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
   };
 
   addToWaitingToLand = async (landRequestOptions: LandRequestOptions) => {
@@ -427,7 +429,8 @@ export class Runner {
       const status = await request.getStatus();
       if (status && status.state !== 'will-queue-when-ready') continue;
 
-      await request.setStatus('queued');
+      const user = await this.client.getUser(request.triggererAaid);
+      await request.setStatus('queued', `queued by ${user.displayName || user.aaid}`);
     }
     Logger.info('Moving landRequests from waiting to queue', {
       namespace: 'lib:runner:moveFromWaitingToQueued',
@@ -444,7 +447,7 @@ export class Runner {
     const displayName = user.displayName || user.aaid;
     await landRequestStatus.request.setStatus(
       'aborted',
-      `Removed from queue by user "${displayName}`,
+      `Removed from queue by user "${displayName}"`,
     );
     Logger.info('Removing landRequest from queue', {
       namespace: 'lib:removeLandRequestFromQueue',

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -228,7 +228,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
     if (this.state.landRequestInfo === null) return null;
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
-    console.log(status);
+
     return (
       <div className="queue-item__more-info">
         {buildId ? (

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -228,7 +228,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
     if (this.state.landRequestInfo === null) return null;
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
-
+    console.log(status);
     return (
       <div className="queue-item__more-info">
         {buildId ? (
@@ -264,7 +264,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
           </div>
         ) : null}
         {status.request.triggererAaid ? (
-          <StatusItem title={status.state === 'aborted' ? 'Aborted By:' : 'Landed by:'}>
+          <StatusItem title="Landed by:">
             <Lozenge>
               <User aaid={status.request.triggererAaid}>
                 {user => {

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -258,7 +258,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
             </StatusItem>
           ))}
         </div>
-        {status.reason && status.reason !== 'queued' ? (
+        {status.reason && status.state !== 'queued' ? (
           <div className="queue-item__status-line">
             <StatusItem title="Reason:">{status.reason}</StatusItem>
           </div>

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -258,7 +258,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
             </StatusItem>
           ))}
         </div>
-        {status.reason ? (
+        {status.reason && status.state !== 'success' ? (
           <div className="queue-item__status-line">
             <StatusItem title="Reason:">{status.reason}</StatusItem>
           </div>

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -264,6 +264,17 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
             <StatusItem title="Reason:">{status.reason}</StatusItem>
           </div>
         ) : null}
+        {status.request.triggererAaid ? (
+          <StatusItem title="Landed By:">
+            <Lozenge>
+              <User aaid={status.request.triggererAaid}>
+                {user => {
+                  return user.displayName;
+                }}
+              </User>
+            </Lozenge>
+          </StatusItem>
+        ) : null}
         {['success', 'fail', 'aborted'].includes(status.state) && dependsOn.length > 0 ? (
           <div className="queue-item__status-line">
             <StatusItem title="Depended On:">{dependsOn.join(', ')}</StatusItem>

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -226,7 +226,6 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
 
   renderMoreInfo = (status: IStatusUpdate, dependsOn: string[], bitbucketBaseUrl: string) => {
     if (this.state.landRequestInfo === null) return null;
-
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
 
@@ -265,7 +264,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
           </div>
         ) : null}
         {status.request.triggererAaid ? (
-          <StatusItem title="Landed By:">
+          <StatusItem title={status.state === 'aborted' ? 'Aborted By:' : 'Landed by'}>
             <Lozenge>
               <User aaid={status.request.triggererAaid}>
                 {user => {

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -264,7 +264,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
           </div>
         ) : null}
         {status.request.triggererAaid ? (
-          <StatusItem title={status.state === 'aborted' ? 'Aborted By:' : 'Landed by'}>
+          <StatusItem title={status.state === 'aborted' ? 'Aborted By:' : 'Landed by:'}>
             <Lozenge>
               <User aaid={status.request.triggererAaid}>
                 {user => {

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -258,7 +258,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
             </StatusItem>
           ))}
         </div>
-        {status.reason && status.state !== 'success' ? (
+        {status.reason && status.reason !== 'queued' ? (
           <div className="queue-item__status-line">
             <StatusItem title="Reason:">{status.reason}</StatusItem>
           </div>


### PR DESCRIPTION
- Adds `Landed by:` field to queue items on the frontend
- Refactors status reason to use the user's `displayName` if it exists, and the `aaid` if it doesn't