### PR TITLE
Adding /clear-land-when-able-queue API 

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -616,6 +616,16 @@ export class Runner {
     await PullRequest.truncate();
   };
 
+  clearLandWhenAbleQueue = async () => {
+    const awaitingRequests = await this.queue.getStatusesForWaitingRequests();
+    for (const status of awaitingRequests) {
+      await status.request.setStatus(
+        'aborted',
+        'Removed from land-when-able-queue manually by admin',
+      );
+    }
+  };
+
   getState = async (requestingUser: ISessionUser): Promise<RunnerState> => {
     const requestingUserMode = await permissionService.getPermissionForUser(requestingUser.aaid);
     const [

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -250,7 +250,8 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
 
       const landRequest: LandRequestOptions = {
         prId,
-        triggererAaid: req.user ? req.user.aaid : 'landkid',
+        // Must always have a valid aaid, so lets set it to Luke's aaid
+        triggererAaid: req.user ? req.user.aaid : '557057:9512f4e4-3319-4d30-a78d-7d5f8ed243ae',
         commit: prInfo.commit,
         prTitle: prInfo.title,
         prAuthorAaid: prInfo.authorAaid,
@@ -282,10 +283,12 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     '/clear-land-when-able-queue',
     requireAuth('admin'),
     wrap(async (req, res) => {
-      Logger.verbose('Deleting land-when-able queue', { namespace: 'routes:api:delete-history' });
+      Logger.verbose('Deleting land-when-able queue', {
+        namespace: 'routes:api:clear-land-when-able-queue',
+      });
       await runner.clearLandWhenAbleQueue();
       res.json({
-        response: 'You may not be a threat but you better stop pretending to be a hero... Done!',
+        response: 'You may not be a threat, but you better stop pretending to be a hero... Done!',
       });
     }),
   );

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -278,6 +278,18 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     }),
   );
 
+  router.delete(
+    '/clear-land-when-able-queue',
+    requireAuth('admin'),
+    wrap(async (req, res) => {
+      Logger.verbose('Deleting land-when-able queue', { namespace: 'routes:api:delete-history' });
+      await runner.clearLandWhenAbleQueue();
+      res.json({
+        response: 'You may not be a threat but you better stop pretending to be a hero... Done!',
+      });
+    }),
+  );
+
   router.post(
     '/to-the-top/:id',
     requireAuth('admin'),


### PR DESCRIPTION
### Description

Adding /clear-land-when-able-queue API to avoid PR stalling in this queue.

### Issue

We are getting some alarms (500x from the load balancer), investigating the issue, it seems coming from PRs that stall in the land-when-able-queue.

This PR adds an endpoint for admin to remove / abort PRs to the land-when-able-queue

### Testing Plan

* Deploy this change to dev / staging landkid environment
* Create a PR
* Land when able this PR
* Add a task to make sure the PR stays in this state
* Run the script with the new endpoint