### PR TITLE
new IsAllowedToLand function that includes an existing request check

### DIFF
--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -17,7 +17,7 @@ export class BitbucketClient {
 
   constructor(private config: Config) {}
 
-  async isAllowedToLand(pullRequestId: number, permissionLevel: IPermissionMode) {
+  async isAllowedToMerge(pullRequestId: number, permissionLevel: IPermissionMode) {
     const pullRequest: BB.PullRequest = await this.bitbucket.getPullRequest(pullRequestId);
     const buildStatuses = await this.bitbucket.getPullRequestBuildStatuses(pullRequestId);
     const author = pullRequest.author;

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -6,7 +6,6 @@ import { config } from '../../../lib/Config';
 import { LandRequestOptions } from '../../../types';
 import { Runner } from '../../../lib/Runner';
 import { Logger } from '../../../lib/Logger';
-import { exist } from 'joi';
 
 export function proxyRoutes(runner: Runner, client: BitbucketClient) {
   const router = express();

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -6,6 +6,7 @@ import { config } from '../../../lib/Config';
 import { LandRequestOptions } from '../../../types';
 import { Runner } from '../../../lib/Runner';
 import { Logger } from '../../../lib/Logger';
+import { exist } from 'joi';
 
 export function proxyRoutes(runner: Runner, client: BitbucketClient) {
   const router = express();
@@ -30,7 +31,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
 
       const errors: string[] = [];
       const warnings: string[] = [];
-      const landCheckErrors: string[] = [];
+      let existingRequest = false;
       const bannerMessage = await runner.getBannerMessageState();
 
       const permissionLevel = await permissionService.getPermissionForUser(aaid);
@@ -39,19 +40,16 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
         if (pauseState) {
           errors.push(`Builds have been manually paused: "${pauseState.reason}"`);
         } else {
-          const landChecks = await client.isAllowedToLand(prId, permissionLevel);
+          const landChecks = await runner.isAllowedToLand(
+            prId,
+            permissionLevel,
+            runner.getWaitingAndQueued,
+          );
           warnings.push(...landChecks.warnings);
           errors.push(...landChecks.errors);
-          landCheckErrors.push(...landChecks.errors);
-
-          const queued = await runner.queue.getQueue();
-          const waiting = await runner.queue.getStatusesForWaitingRequests();
-
-          for (const queueItem of [...queued, ...waiting]) {
-            if (queueItem.request.pullRequest.prId === prId) {
-              errors.push('This PR has already been queued, patience young padawan');
-              break;
-            }
+          if (landChecks.existingRequest) {
+            existingRequest = true;
+            errors.push('This PR has already been queued, patience young padawan');
           }
         }
       } else {
@@ -66,7 +64,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
 
       res.json({
         canLand: errors.length === 0,
-        canLandWhenAble: errors.length === landCheckErrors.length && prSettings.allowLandWhenAble,
+        canLandWhenAble: !existingRequest && prSettings.allowLandWhenAble,
         errors,
         warnings,
         bannerMessage,


### PR DESCRIPTION
- changed `isAllowedToLand` -> `isAllowedToMerge`
- created new `isAllowedToLand` in the runner that calls `isAllowedToMerge` then does a check for an existing request
  - Accepts a function that returns a list of land requests so that the existing request can be searched for in different queues