### PR TITLE
Resolve lodash to ^4.17.21 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
     "umzug": "^2.2.0",
     "winston": "^3.1.0"
   },
+  "resolutions": {
+    "lodash": "^4.17.21"
+  },
   "lint-staged": {
     "*.js": [
       "prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,10 +6078,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.19, lodash@^4.12.0, lodash@^4.17.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+lodash@4.17.19, lodash@^4.12.0, lodash@^4.17.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4:
+  version "4.17.21"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=
 
 log-symbols@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
https://sca.analysiscenter.veracode.com/vulnerability-database/vulnerabilities/29405

**Affected versions**: 0.1.0-4.17.20. 
**Patch:** https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c  
**SourceClear** recommends updating to: 4.17.21 (or newer)