### PR TITLE
Add `skipBuildOnDependentsAwaitingMerge` config option

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -45,6 +45,9 @@ module.exports = {
      * otherwise return the error message to be displayed on the PR
      */
   },
+  mergeSettings: {
+    skipBuildOnDependentsAwaitingMerge: false,
+  },
   eventListeners: [
     {
       event: 'PULL_REQUEST.MERGE.SUCCESS',

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 import * as jwtTools from 'atlassian-jwt';
 import delay from 'delay';
 
-import { RepoConfig } from '../types';
+import { MergeOptions, RepoConfig } from '../types';
 import { Logger } from '../lib/Logger';
 import { bitbucketAuthenticator, axiosPostConfig } from './BitbucketAuthenticator';
 import { LandRequestStatus } from '../db';
@@ -14,7 +14,7 @@ export class BitbucketAPI {
 
   constructor(private config: RepoConfig) {}
 
-  mergePullRequest = async (landRequestStatus: LandRequestStatus) => {
+  mergePullRequest = async (landRequestStatus: LandRequestStatus, options: MergeOptions = {}) => {
     const {
       id: landRequestId,
       request: {
@@ -23,7 +23,10 @@ export class BitbucketAPI {
       },
     } = landRequestStatus;
     const endpoint = `${this.apiBaseUrl}/pullrequests/${pullRequestId}/merge`;
-    const message = `pull request #${pullRequestId} merged by Landkid after a successful build rebased on ${targetBranch}`;
+    let message = `pull request #${pullRequestId} merged by Landkid after a successful build rebased on ${targetBranch}`;
+    if (options.skipCI) {
+      message += '\n\n[skip ci]';
+    }
     const requestBody = {
       close_source_branch: true,
       message,

--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Config } from '../types';
+import { Config, MergeOptions } from '../types';
 import { Logger } from '../lib/Logger';
 import { BitbucketPipelinesAPI, PipelinesVariables } from './BitbucketPipelinesAPI';
 import { BitbucketAPI } from './BitbucketAPI';
@@ -98,8 +98,8 @@ export class BitbucketClient {
     return this.pipelines.stopLandBuild(buildId, lockId);
   }
 
-  async mergePullRequest(landRequestStatus: LandRequestStatus) {
-    return this.bitbucket.mergePullRequest(landRequestStatus);
+  async mergePullRequest(landRequestStatus: LandRequestStatus, options?: MergeOptions) {
+    return this.bitbucket.mergePullRequest(landRequestStatus, options);
   }
 
   processStatusWebhook(body: any): BB.BuildStatusEvent | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,16 @@ export type Config = {
   sequelize?: any;
   eventListeners?: EventListener[];
   easterEgg?: any;
+  mergeSettings?: MergeSettings;
+};
+
+export type MergeSettings = {
+  /** Skip the destination branch build when there are successful dependent requests awaiting merge.
+   * This prevents multiple branch builds triggering multiple merges happen in quick succession.
+   * Achieved by adding [skip ci] to the merge commit message
+   */
+  skipBuildOnDependentsAwaitingMerge?: boolean;
+  // waitForBuild?: { // TBD };
 };
 
 export type RunnerState = {
@@ -105,4 +115,8 @@ export type RunnerState = {
   bannerMessageState: IMessageState | null;
   bitbucketBaseUrl: string;
   permissionsMessage: string;
+};
+
+export type MergeOptions = {
+  skipCI?: boolean;
 };

--- a/tests/unit/BitbucketAPI.test.ts
+++ b/tests/unit/BitbucketAPI.test.ts
@@ -86,4 +86,17 @@ describe('mergePullRequest', () => {
     expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
     expect(mockedDelay).toHaveBeenCalledTimes(2);
   });
+
+  test('Skip-ci merge', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+    await bitbucketAPI.mergePullRequest(landRequestStatus as any, { skipCI: true });
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      'Attempting to merge pull request',
+      expect.objectContaining({
+        postRequest: expect.objectContaining({
+          message: expect.stringContaining('[skip ci]'),
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
When set, merge commits for PRs will opt out of the destination branch
build via [skip ci] when there are successful dependent PRs awaiting
merge.
This prevents multiple destination branch builds from triggering when
PRs are landed in quick succession which can affect builds that update
src and push back to the repo such as publishing new versions of npm
libraries.