### PR TITLE
New state for when a PR is in the process of merging

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -14,11 +14,7 @@ export class BitbucketAPI {
 
   constructor(private config: RepoConfig) {}
 
-  mergePullRequest = async (
-    landRequestStatus: LandRequestStatus,
-    callback: () => Promise<void>,
-    options: MergeOptions = {},
-  ) => {
+  mergePullRequest = async (landRequestStatus: LandRequestStatus, options: MergeOptions = {}) => {
     const {
       id: landRequestId,
       request: {
@@ -166,15 +162,13 @@ export class BitbucketAPI {
     // 5 attempts total
     await attemptMerge(1, 4);
 
-    // We throw before here if the merge is unsuccessul
+    // We throw before here if the merge is unsuccessful
     Logger.info('Merged Pull Request', {
       namespace: 'bitbucket:api:mergePullRequest',
       landRequestId,
       landRequestStatus,
       pullRequestId,
     });
-
-    await callback();
   };
 
   getPullRequest = async (pullRequestId: number): Promise<BB.PullRequest> => {

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -14,7 +14,11 @@ export class BitbucketAPI {
 
   constructor(private config: RepoConfig) {}
 
-  mergePullRequest = async (landRequestStatus: LandRequestStatus, options: MergeOptions = {}) => {
+  mergePullRequest = async (
+    landRequestStatus: LandRequestStatus,
+    callback: () => Promise<void>,
+    options: MergeOptions = {},
+  ) => {
     const {
       id: landRequestId,
       request: {
@@ -169,6 +173,8 @@ export class BitbucketAPI {
       landRequestStatus,
       pullRequestId,
     });
+
+    await callback();
   };
 
   getPullRequest = async (pullRequestId: number): Promise<BB.PullRequest> => {

--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -98,12 +98,8 @@ export class BitbucketClient {
     return this.pipelines.stopLandBuild(buildId, lockId);
   }
 
-  async mergePullRequest(
-    landRequestStatus: LandRequestStatus,
-    callback: () => Promise<void>,
-    options?: MergeOptions,
-  ) {
-    return this.bitbucket.mergePullRequest(landRequestStatus, callback, options);
+  async mergePullRequest(landRequestStatus: LandRequestStatus, options?: MergeOptions) {
+    return this.bitbucket.mergePullRequest(landRequestStatus, options);
   }
 
   processStatusWebhook(body: any): BB.BuildStatusEvent | null {

--- a/src/bitbucket/BitbucketClient.ts
+++ b/src/bitbucket/BitbucketClient.ts
@@ -98,8 +98,12 @@ export class BitbucketClient {
     return this.pipelines.stopLandBuild(buildId, lockId);
   }
 
-  async mergePullRequest(landRequestStatus: LandRequestStatus, options?: MergeOptions) {
-    return this.bitbucket.mergePullRequest(landRequestStatus, options);
+  async mergePullRequest(
+    landRequestStatus: LandRequestStatus,
+    callback: () => Promise<void>,
+    options?: MergeOptions,
+  ) {
+    return this.bitbucket.mergePullRequest(landRequestStatus, callback, options);
   }
 
   processStatusWebhook(body: any): BB.BuildStatusEvent | null {

--- a/src/bitbucket/descriptor.ts
+++ b/src/bitbucket/descriptor.ts
@@ -45,7 +45,9 @@ export const makeDescriptor = () => ({
         key: 'atlaskid-addon-panel',
         name: {
           value: `Landkid Queue${
-            process.env.LANDKID_DEPLOYMENT !== 'prod' ? ` (${process.env.LANDKID_DEPLOYMENT})` : ''
+            process.env.LANDKID_DEPLOYMENT !== 'prod'
+              ? ` (${process.env.LANDKID_DEPLOYMENT || 'local'})`
+              : ''
           }`,
         },
         url:

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -172,6 +172,7 @@ export class LandRequestStatus extends Model<LandRequestStatus> implements IStat
         'queued',
         'running',
         'awaiting-merge',
+        'merging',
         'success',
         'fail',
         'aborted',

--- a/src/lib/AccountService.ts
+++ b/src/lib/AccountService.ts
@@ -43,6 +43,7 @@ export class AccountService {
 
         return JSON.parse(cached);
       },
+      undefined,
     );
     return info || this.getAccountInfo(aaid, retry - 1);
   };

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -229,26 +229,34 @@ export class Runner {
         landRequestId: landRequest.id,
         lockId,
       });
-      await this.client.mergePullRequest(landRequestStatus, { skipCI });
-      Logger.info('Successfully merged PR', {
+
+      await landRequest.setStatus('merging');
+      this.client.mergePullRequest(
+        landRequestStatus,
+        async () => {
+          const end = Date.now();
+          const queuedDate = await this.getLandRequestQueuedDate(landRequest.id);
+          const start = queuedDate!.getTime();
+          eventEmitter.emit('PULL_REQUEST.MERGE.SUCCESS', {
+            landRequestId: landRequestStatus.requestId,
+            pullRequestId: landRequest.pullRequestId,
+            commit: landRequest.forCommit,
+            sourceBranch: pullRequest.sourceBranch,
+            targetBranch: pullRequest.targetBranch,
+            duration: end - start,
+          });
+          landRequest.setStatus('success');
+        },
+        { skipCI },
+      );
+
+      Logger.info('Moved request to merging', {
         namespace: 'lib:runner:moveFromAwaitingMerge',
         landRequestId: landRequest.id,
         pullRequestId,
         lockId,
       });
-
-      const end = Date.now();
-      const queuedDate = await this.getLandRequestQueuedDate(landRequest.id);
-      const start = queuedDate!.getTime();
-      eventEmitter.emit('PULL_REQUEST.MERGE.SUCCESS', {
-        landRequestId: landRequestStatus.requestId,
-        pullRequestId: landRequest.pullRequestId,
-        commit: landRequest.forCommit,
-        sourceBranch: pullRequest.sourceBranch,
-        targetBranch: pullRequest.targetBranch,
-        duration: end - start,
-      });
-      return landRequest.setStatus('success');
+      return true;
     } catch (err) {
       eventEmitter.emit('PULL_REQUEST.MERGE.FAIL', {
         landRequestId: landRequestStatus.requestId,
@@ -263,54 +271,58 @@ export class Runner {
 
   // Next must always return early if ever doing a single state transition
   next = async () => {
-    const runNextAgain = await withLock('status-transition', async (lockId: Date) => {
-      const queue = await this.queue.getQueue();
-      Logger.info('Next() called', {
-        namespace: 'lib:runner:next',
-        lockId,
-        queue,
-      });
+    const runNextAgain = await withLock(
+      'status-transition',
+      async (lockId: Date) => {
+        const queue = await this.queue.getQueue();
+        Logger.info('Next() called', {
+          namespace: 'lib:runner:next',
+          lockId,
+          queue,
+        });
 
-      for (const landRequestStatus of queue) {
-        // Check for this _before_ looking at the state so that we don't have to wait until
-        const landRequest = landRequestStatus.request;
-        const failedDeps = await landRequest.getFailedDependencies();
-        if (failedDeps.length !== 0) {
-          Logger.info('LandRequest failed due to failing dependency', {
-            namespace: 'lib:runner:next',
-            lockId,
-            landRequestId: landRequest.id,
-            pullRequestId: landRequest.pullRequestId,
-            landRequestStatus,
-            failedDeps,
-          });
-          const failedPrIds = failedDeps.map(d => d.request.pullRequestId).join(', ');
-          const failReason = `Failed due to failed dependency builds: ${failedPrIds}`;
-          await landRequest.setStatus('fail', failReason);
-          await landRequest.update({ dependsOn: null });
-          await this.client.stopLandBuild(landRequest.buildId, lockId);
-          const user = await this.client.getUser(landRequest.triggererAaid);
-          return landRequest.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
+        for (const landRequestStatus of queue) {
+          // Check for this _before_ looking at the state so that we don't have to wait until
+          const landRequest = landRequestStatus.request;
+          const failedDeps = await landRequest.getFailedDependencies();
+          if (failedDeps.length !== 0) {
+            Logger.info('LandRequest failed due to failing dependency', {
+              namespace: 'lib:runner:next',
+              lockId,
+              landRequestId: landRequest.id,
+              pullRequestId: landRequest.pullRequestId,
+              landRequestStatus,
+              failedDeps,
+            });
+            const failedPrIds = failedDeps.map(d => d.request.pullRequestId).join(', ');
+            const failReason = `Failed due to failed dependency builds: ${failedPrIds}`;
+            await landRequest.setStatus('fail', failReason);
+            await landRequest.update({ dependsOn: null });
+            await this.client.stopLandBuild(landRequest.buildId, lockId);
+            const user = await this.client.getUser(landRequest.triggererAaid);
+            return landRequest.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
+          }
+          if (landRequestStatus.state === 'awaiting-merge') {
+            const awaitingMergeQueue = Runner.getDependentsAwaitingMerge(queue, landRequestStatus);
+            const didChangeState = await this.moveFromAwaitingMerge(
+              landRequestStatus,
+              lockId,
+              awaitingMergeQueue,
+            );
+            // if we moved, we need to exit early, otherwise, just keep checking the queue
+            if (didChangeState) return true;
+          } else if (landRequestStatus.state === 'queued') {
+            const didChangeState = await this.moveFromQueueToRunning(landRequestStatus, lockId);
+            // if the landrequest was able to move from queued to running, exit early, otherwise, keep
+            // checking the rest of the queue
+            if (didChangeState) return true;
+          }
+          // otherwise, we must just be running, nothing to do here
         }
-        if (landRequestStatus.state === 'awaiting-merge') {
-          const awaitingMergeQueue = Runner.getDependentsAwaitingMerge(queue, landRequestStatus);
-          const didChangeState = await this.moveFromAwaitingMerge(
-            landRequestStatus,
-            lockId,
-            awaitingMergeQueue,
-          );
-          // if we moved, we need to exit early, otherwise, just keep checking the queue
-          if (didChangeState) return true;
-        } else if (landRequestStatus.state === 'queued') {
-          const didChangeState = await this.moveFromQueueToRunning(landRequestStatus, lockId);
-          // if the landrequest was able to move from queued to running, exit early, otherwise, keep
-          // checking the rest of the queue
-          if (didChangeState) return true;
-        }
-        // otherwise, we must just be running, nothing to do here
-      }
-      return false;
-    });
+        return false;
+      },
+      false,
+    );
     if (runNextAgain) {
       await this.next();
     }
@@ -522,42 +534,46 @@ export class Runner {
   };
 
   checkWaitingLandRequests = async () => {
-    await withLock('status-transition', async () => {
-      const waitingRequestStatuses = await this.queue.getStatusesForWaitingRequests();
+    await withLock(
+      'status-transition',
+      async () => {
+        const waitingRequestStatuses = await this.queue.getStatusesForWaitingRequests();
 
-      Logger.info('Checking for waiting landrequests ready to queue', {
-        namespace: 'lib:runner:checkWaitingLandRequests',
-        waitingRequestStatuses,
-      });
+        Logger.info('Checking for waiting landrequests ready to queue', {
+          namespace: 'lib:runner:checkWaitingLandRequests',
+          waitingRequestStatuses,
+        });
 
-      for (const landRequestStatus of waitingRequestStatuses) {
-        const landRequest = landRequestStatus.request;
-        const pullRequestId = landRequest.pullRequestId;
-        const triggererUserMode = await permissionService.getPermissionForUser(
-          landRequest.triggererAaid,
-        );
-        const isAllowedToLand = await this.isAllowedToLand(
-          pullRequestId,
-          triggererUserMode,
-          this.getQueue,
-        );
+        for (const landRequestStatus of waitingRequestStatuses) {
+          const landRequest = landRequestStatus.request;
+          const pullRequestId = landRequest.pullRequestId;
+          const triggererUserMode = await permissionService.getPermissionForUser(
+            landRequest.triggererAaid,
+          );
+          const isAllowedToLand = await this.isAllowedToLand(
+            pullRequestId,
+            triggererUserMode,
+            this.getQueue,
+          );
 
-        if (isAllowedToLand.errors.length === 0) {
-          if (isAllowedToLand.existingRequest) {
-            Logger.warn('Already has existing Land build', {
-              pullRequestId,
-              landRequestId: landRequest.id,
-              landRequestStatus,
-              namespace: 'lib:runner:checkWaitingLandRequests',
-            });
-            await landRequest.setStatus('aborted', 'Already has existing Land build');
-            continue;
+          if (isAllowedToLand.errors.length === 0) {
+            if (isAllowedToLand.existingRequest) {
+              Logger.warn('Already has existing Land build', {
+                pullRequestId,
+                landRequestId: landRequest.id,
+                landRequestStatus,
+                namespace: 'lib:runner:checkWaitingLandRequests',
+              });
+              await landRequest.setStatus('aborted', 'Already has existing Land build');
+              continue;
+            }
+            const movedState = await this.moveFromWaitingToQueued(landRequestStatus);
+            if (movedState) return this.next();
           }
-          const movedState = await this.moveFromWaitingToQueued(landRequestStatus);
-          if (movedState) return this.next();
         }
-      }
-    });
+      },
+      undefined,
+    );
   };
 
   getStatusesForLandRequests = async (

--- a/src/lib/utils/locker.ts
+++ b/src/lib/utils/locker.ts
@@ -4,7 +4,11 @@ import { Logger } from '../Logger';
 
 const redlock = new RedLock([client]);
 
-export const withLock = async <T>(resource: string, fn: (lockId: Date) => Promise<T>) => {
+export const withLock = async <T>(
+  resource: string,
+  fn: (lockId: Date) => Promise<T>,
+  fallback: T,
+) => {
   let lock: RedLock.Lock;
   let lockId: Date;
   try {
@@ -15,7 +19,7 @@ export const withLock = async <T>(resource: string, fn: (lockId: Date) => Promis
       lockId,
     });
   } catch {
-    return;
+    return fallback;
   }
   let result: T;
   try {

--- a/src/static/current-state/components/Header.tsx
+++ b/src/static/current-state/components/Header.tsx
@@ -18,14 +18,7 @@ const userInfoStyles = css({
 });
 
 const userNameStyles = css({
-  marginRight: 8,
   fontWeight: 'bold',
-});
-
-const userImgStyles = css({
-  height: 32,
-  width: 32,
-  borderRadius: '100%',
 });
 
 interface HeaderProps {
@@ -38,10 +31,6 @@ export const Header: React.FunctionComponent<HeaderProps> = ({ user }) => (
     {user ? (
       <div className={userInfoStyles}>
         <span className={userNameStyles}>{user.displayName}</span>
-        <img
-          src={`https://bitbucket.org/account/${user.username}/avatar/`}
-          className={userImgStyles}
-        />
       </div>
     ) : null}
   </div>

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -154,9 +154,10 @@ export const StatusItem: React.FunctionComponent<StatusItemProps> = props => (
 
 const landStatusToAppearance: Record<IStatusUpdate['state'], LozengeAppearance> = {
   'will-queue-when-ready': 'new',
-  'awaiting-merge': 'new',
   queued: 'new',
   running: 'inprogress',
+  'awaiting-merge': 'new',
+  merging: 'new',
   success: 'success',
   fail: 'removed',
   aborted: 'moved',
@@ -164,9 +165,10 @@ const landStatusToAppearance: Record<IStatusUpdate['state'], LozengeAppearance> 
 
 const landStatusToNiceString: Record<IStatusUpdate['state'], string> = {
   'will-queue-when-ready': 'Waiting to Land',
-  'awaiting-merge': 'Awaiting Merge',
   queued: 'In Queue',
   running: 'Running',
+  'awaiting-merge': 'Awaiting Merge',
+  merging: 'Merging',
   success: 'Succeeded',
   aborted: 'Aborted',
   fail: 'Failed',
@@ -174,9 +176,10 @@ const landStatusToNiceString: Record<IStatusUpdate['state'], string> = {
 
 const landStatusToPastTense: Record<IStatusUpdate['state'], string> = {
   'will-queue-when-ready': 'Told To Land When Ready',
-  'awaiting-merge': 'Told to Merge',
   queued: 'Told To Land',
   running: 'Started',
+  'awaiting-merge': 'Ready to Merge',
+  merging: 'Merge Started',
   success: 'Succeeded',
   fail: 'Failed',
   aborted: 'Aborted',

--- a/tests/integration/utils/index.ts
+++ b/tests/integration/utils/index.ts
@@ -3,10 +3,11 @@ import * as Joi from 'joi';
 const queued = Joi.string().valid('queued');
 const running = Joi.string().valid('running');
 const awaitingmerge = Joi.string().valid('awaitingmerge');
+const merging = Joi.string().valid('merging');
 const fail = Joi.string().valid('fail');
 const success = Joi.string().valid('success');
 
-const successfulFlow = [queued, running, awaitingmerge, success];
+const successfulFlow = [queued, running, awaitingmerge, merging, success];
 const failedFlow = [queued, running, fail];
 const failedDepFlow = [queued, running, awaitingmerge.optional(), fail];
 

--- a/tests/unit/BitbucketAPI.test.ts
+++ b/tests/unit/BitbucketAPI.test.ts
@@ -35,7 +35,7 @@ const bitbucketAPI = new BitbucketAPI({
 });
 
 const mergePullRequest = (request: any, opts?: MergeOptions) =>
-  bitbucketAPI.mergePullRequest(request, async () => {}, opts);
+  bitbucketAPI.mergePullRequest(request, opts);
 
 describe('mergePullRequest', () => {
   beforeEach(() => {

--- a/tests/unit/BitbucketAPI.test.ts
+++ b/tests/unit/BitbucketAPI.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import delay from 'delay';
 import { Logger } from '../../src/lib/Logger';
 import { BitbucketAPI } from '../../src/bitbucket/BitbucketAPI';
+import { MergeOptions } from '../../src/types';
 
 jest.mock('axios');
 const mockedAxios = (axios as unknown) as jest.Mocked<typeof axios>;
@@ -33,6 +34,9 @@ const bitbucketAPI = new BitbucketAPI({
   repoOwner: 'owner',
 });
 
+const mergePullRequest = (request: any, opts?: MergeOptions) =>
+  bitbucketAPI.mergePullRequest(request, async () => {}, opts);
+
 describe('mergePullRequest', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -40,27 +44,27 @@ describe('mergePullRequest', () => {
 
   test('Successful merge first try', async () => {
     mockedAxios.post.mockResolvedValue({ status: 200 });
-    await bitbucketAPI.mergePullRequest(landRequestStatus as any);
+    await mergePullRequest(landRequestStatus);
     expect(loggerInfoSpy).toHaveBeenCalledTimes(2);
   });
 
   test('Legitimate 4xx merge failure', async () => {
     mockedAxios.post.mockResolvedValue({ status: 400 });
-    await expect(bitbucketAPI.mergePullRequest(landRequestStatus as any)).rejects.toThrow();
+    await expect(mergePullRequest(landRequestStatus)).rejects.toThrow();
     expect(loggerInfoSpy).toHaveBeenCalledTimes(1);
     expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
   });
 
   test('Retry because of 5xx error and fail all attempts', async () => {
     mockedAxios.post.mockResolvedValue({ status: 500 });
-    await expect(bitbucketAPI.mergePullRequest(landRequestStatus as any)).rejects.toThrow();
+    await expect(mergePullRequest(landRequestStatus)).rejects.toThrow();
     expect(loggerInfoSpy).toHaveBeenCalledTimes(1);
     expect(loggerErrorSpy).toHaveBeenCalledTimes(6);
   });
 
   test('Succeed on first retry', async () => {
     mockedAxios.post.mockResolvedValueOnce({ status: 500 }).mockResolvedValueOnce({ status: 200 });
-    await bitbucketAPI.mergePullRequest(landRequestStatus as any);
+    await mergePullRequest(landRequestStatus);
     expect(loggerInfoSpy).toHaveBeenCalledTimes(2);
     expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
   });
@@ -70,7 +74,7 @@ describe('mergePullRequest', () => {
     mockedAxios.get
       .mockResolvedValueOnce({ data: { task_status: 'PENDING' } })
       .mockResolvedValueOnce({ data: { task_status: 'SUCCESSFUL' } });
-    await bitbucketAPI.mergePullRequest(landRequestStatus as any);
+    await mergePullRequest(landRequestStatus);
     expect(loggerInfoSpy).toHaveBeenCalledTimes(3);
     expect(mockedDelay).toHaveBeenCalledTimes(1);
   });
@@ -81,7 +85,7 @@ describe('mergePullRequest', () => {
       .mockResolvedValueOnce({ data: { task_status: 'PENDING' } })
       .mockResolvedValueOnce({ data: { task_status: 'PENDING' } })
       .mockRejectedValueOnce({ response: {} });
-    await expect(bitbucketAPI.mergePullRequest(landRequestStatus as any)).rejects.toThrow();
+    await expect(mergePullRequest(landRequestStatus)).rejects.toThrow();
     expect(loggerInfoSpy).toHaveBeenCalledTimes(2);
     expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
     expect(mockedDelay).toHaveBeenCalledTimes(2);
@@ -89,7 +93,7 @@ describe('mergePullRequest', () => {
 
   test('Skip-ci merge', async () => {
     mockedAxios.post.mockResolvedValue({ status: 200 });
-    await bitbucketAPI.mergePullRequest(landRequestStatus as any, { skipCI: true });
+    await mergePullRequest(landRequestStatus, { skipCI: true });
     expect(loggerInfoSpy).toHaveBeenCalledWith(
       'Attempting to merge pull request',
       expect.objectContaining({

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -52,6 +52,7 @@ declare interface IStatusUpdate {
     | 'queued'
     | 'running'
     | 'awaiting-merge'
+    | 'merging'
     | 'success'
     | 'fail'
     | 'aborted';


### PR DESCRIPTION
This avoids the issue where merging takes longer than the TTL of the `status-transition` lock which allows another merge attempt to be triggered, causing the land request to say "Unable to merge pull request" despite having successfully merged it.