### PR TITLE
PRs that are merging disappear from the Landkid current-state view

### DIFF
--- a/src/static/current-state/components/RunningBuilds.tsx
+++ b/src/static/current-state/components/RunningBuilds.tsx
@@ -8,7 +8,7 @@ export type Props = {
 };
 
 function findRunning(updates: IStatusUpdate[]) {
-  return updates.filter(update => ['running', 'awaiting-merge'].includes(update.state));
+  return updates.filter(update => ['running', 'awaiting-merge', 'merging'].includes(update.state));
 }
 
 export const RunningBuilds: React.FunctionComponent<Props> = props => {


### PR DESCRIPTION
We should show them in the running section.