### PR TITLE
Land request priority system

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "joi": "^14.3.1",
     "lint-staged": "^5.0.0",
     "nodemon": "^1.18.6",
-    "prettier": "^1.8.2",
+    "prettier": "^2.3.0",
     "rimraf": "^2.6.2",
     "rxjs-compat": "^6.3.3",
     "sqlite3": "^5.0.0",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -67,6 +67,11 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   @Column(Sequelize.STRING)
   dependsOn: string;
 
+  @AllowNull(true)
+  @Default(0)
+  @Column(Sequelize.INTEGER)
+  priority: number;
+
   getStatus = async () => {
     return LandRequestStatus.findOne<LandRequestStatus>({
       where: {
@@ -78,7 +83,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   };
 
   setStatus = async (state: LandRequestStatus['state'], reason?: string, date?: Date) => {
-    await this.sequelize.transaction(async t => {
+    await this.sequelize.transaction(async (t) => {
       // First we'll check if there is an old status for this LandRequest
       await LandRequestStatus.update(
         {
@@ -145,6 +150,15 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
     });
 
     return failedDependencies;
+  };
+
+  updatePriority = (newPriority: number) => {
+    this.priority = newPriority;
+    return this.save();
+  };
+
+  incrementPriority = () => {
+    return this.updatePriority(this.priority + 1);
   };
 }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -160,6 +160,10 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   incrementPriority = () => {
     return this.updatePriority(this.priority + 1);
   };
+
+  decrementPriority = () => {
+    return this.updatePriority(this.priority - 1);
+  };
 }
 
 @Table

--- a/src/db/migrations/06__priorityColumn.ts
+++ b/src/db/migrations/06__priorityColumn.ts
@@ -1,0 +1,18 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  up: function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.describeTable('LandRequest').then((table: any) => {
+      if (table.priority) return;
+      return query.addColumn('LandRequest', 'priority', {
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+        allowNull: true,
+      });
+    });
+  },
+  // VIOLATES FOREIGN KEY CONSTRAINT
+  down: function () {
+    throw new Error('NO DROP FUNCTION FOR THIS MIGRATION');
+  },
+};

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -61,7 +61,7 @@ export class Runner {
     const landRequest = landRequestStatus.request;
     const running = await this.getRunning();
     const runningTargetingSameBranch = running.filter(
-      build => build.request.pullRequest.targetBranch === landRequest.pullRequest.targetBranch,
+      (build) => build.request.pullRequest.targetBranch === landRequest.pullRequest.targetBranch,
     );
     const maxConcurrentBuilds = this.getMaxConcurrentBuilds();
     if (runningTargetingSameBranch.length >= maxConcurrentBuilds) {
@@ -128,7 +128,7 @@ export class Runner {
 
     const runningExceptSelf = runningTargetingSameBranch.filter(
       // Failsafe to prevent self-dependencies
-      build => build.request.pullRequestId !== landRequest.pullRequestId,
+      (build) => build.request.pullRequestId !== landRequest.pullRequestId,
     );
     const dependencies = [];
     for (const queueItem of runningExceptSelf) {
@@ -139,7 +139,7 @@ export class Runner {
 
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
-    const dependsOnStr = dependencies.map(queueItem => queueItem.request.id).join(',');
+    const dependsOnStr = dependencies.map((queueItem) => queueItem.request.id).join(',');
 
     Logger.info('Attempting to move from queued to running', {
       namespace: 'lib:runner:moveFromQueueToRunning',
@@ -154,7 +154,7 @@ export class Runner {
       landRequest.id,
       commit,
       {
-        dependencyCommits: dependencies.map(queueItem => queueItem.request.forCommit),
+        dependencyCommits: dependencies.map((queueItem) => queueItem.request.forCommit),
         targetBranch: landRequest.pullRequest.targetBranch,
       },
       lockId,
@@ -174,7 +174,7 @@ export class Runner {
     if (dependencies.length > 0) {
       depPrsStr =
         'Started with PR dependencies: ' +
-        dependencies.map(queueItem => queueItem.request.pullRequestId).join(', ');
+        dependencies.map((queueItem) => queueItem.request.pullRequestId).join(', ');
     }
 
     await landRequest.setStatus('running', depPrsStr);
@@ -204,7 +204,7 @@ export class Runner {
     const pullRequest = landRequest.pullRequest;
     const dependencies = await landRequest.getDependencies();
 
-    if (!dependencies.every(dep => dep.statuses[0].state === 'success')) {
+    if (!dependencies.every((dep) => dep.statuses[0].state === 'success')) {
       Logger.info('LandRequest is awaiting-merge but still waiting on dependencies', {
         namespace: 'lib:runner:moveFromAwaitingMerge',
         pullRequestId: landRequest.pullRequestId,
@@ -232,7 +232,7 @@ export class Runner {
       this.config.mergeSettings &&
       this.config.mergeSettings.skipBuildOnDependentsAwaitingMerge;
 
-    this.client.mergePullRequest(landRequestStatus, { skipCI }).then(async result => {
+    this.client.mergePullRequest(landRequestStatus, { skipCI }).then(async (result) => {
       if (result === BitbucketAPI.SUCCESS) {
         const end = Date.now();
         const queuedDate = await this.getLandRequestQueuedDate(landRequest.id);
@@ -297,7 +297,7 @@ export class Runner {
       landRequestStatus,
       failedDeps,
     });
-    const failedPrIds = failedDeps.map(d => d.request.pullRequestId).join(', ');
+    const failedPrIds = failedDeps.map((d) => d.request.pullRequestId).join(', ');
     const failReason = `Failed due to failed dependency builds: ${failedPrIds}`;
     await landRequest.setStatus('fail', failReason);
     await landRequest.update({ dependsOn: null });
@@ -406,7 +406,7 @@ export class Runner {
     const running = await this.getRunning();
     if (!running || !running.length) return false;
 
-    const landRequestStatus = running.find(status => status.requestId === requestId);
+    const landRequestStatus = running.find((status) => status.requestId === requestId);
     if (!landRequestStatus) return false;
 
     await landRequestStatus.request.setStatus(
@@ -487,12 +487,13 @@ export class Runner {
     });
   };
 
-  enqueue = async (landRequestOptions: LandRequestOptions): Promise<void> => {
+  enqueue = async (landRequestOptions: LandRequestOptions) => {
     // TODO: Ensure no land request is pending for this PR
     if (await this.getPauseState()) return;
     const request = await this.createRequestFromOptions(landRequestOptions);
     const user = await this.client.getUser(request.triggererAaid);
     await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
+    return request;
   };
 
   addToWaitingToLand = async (landRequestOptions: LandRequestOptions) => {
@@ -502,6 +503,7 @@ export class Runner {
     await request.setStatus('will-queue-when-ready');
 
     this.checkWaitingLandRequests();
+    return request;
   };
 
   moveFromWaitingToQueued = async (landRequestStatus: LandRequestStatus) => {
@@ -739,21 +741,15 @@ export class Runner {
 
   getState = async (requestingUser: ISessionUser): Promise<RunnerState> => {
     const requestingUserMode = await permissionService.getPermissionForUser(requestingUser.aaid);
-    const [
-      daysSinceLastFailure,
-      pauseState,
-      queue,
-      users,
-      waitingToQueue,
-      bannerMessageState,
-    ] = await Promise.all([
-      this.getDatesSinceLastFailures(),
-      this.getPauseState(),
-      requestingUserMode === 'read' ? [] : this.getQueue(),
-      this.getUsersPermissions(requestingUserMode),
-      requestingUserMode === 'read' ? [] : this.queue.getStatusesForWaitingRequests(),
-      this.getBannerMessageState(),
-    ]);
+    const [daysSinceLastFailure, pauseState, queue, users, waitingToQueue, bannerMessageState] =
+      await Promise.all([
+        this.getDatesSinceLastFailures(),
+        this.getPauseState(),
+        requestingUserMode === 'read' ? [] : this.getQueue(),
+        this.getUsersPermissions(requestingUserMode),
+        requestingUserMode === 'read' ? [] : this.queue.getStatusesForWaitingRequests(),
+        this.getBannerMessageState(),
+      ]);
     // We are ignoring errors because the IDE thinks all returned values can be null
     // However, this is operating as intended
     return {
@@ -774,7 +770,7 @@ export class Runner {
 
   static getDependentsAwaitingMerge(queue: LandRequestStatus[], currentStatus: LandRequestStatus) {
     return queue.filter(
-      status =>
+      (status) =>
         status.state === 'awaiting-merge' &&
         status.request.dependsOn.split(',').includes(String(currentStatus.request.id)),
     );

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -303,19 +303,24 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
   );
 
   router.post(
-    '/to-the-top/:id',
+    '/priority/:id',
     requireAuth('admin'),
     wrap(async (req, res) => {
       const requestId = req.params.id;
-      Logger.verbose('Moving landrequest to the top of the queue', {
-        namespace: 'routes:api:to-the-top',
+      if (!req.body || req.body.priority === undefined || req.body.priority === null) {
+        return res.status(400).json({ err: 'req.body.priority expected', body: req.body });
+      }
+      const { priority } = req.body;
+      Logger.verbose('Updating priority of land request', {
+        namespace: 'routes:api:priority',
         requestId,
+        priority,
       });
-      const success = await runner.moveRequestToTopOfQueue(requestId, req.user!);
+      const success = await runner.updateLandRequestPriority(requestId, priority);
       if (success) {
-        res.json({ message: 'Request moved to top of queue' });
+        res.json({ message: 'Updated priority of request' });
       } else {
-        res.status(400).json({ error: 'Request either does not exist or is not queued' });
+        res.status(404).json({ error: 'Request does not exist' });
       }
     }),
   );

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -317,10 +317,13 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       const requestId = req.params.id;
-      if (!req.body || req.body.priority === undefined || req.body.priority === null) {
-        return res.status(400).json({ err: 'req.body.priority expected', body: req.body });
+      if (!req.body) {
+        return res.status(400).json({ err: 'body expected' });
       }
-      const { priority } = req.body;
+      const priority = parseInt(req.body.priority, 10);
+      if (isNaN(priority)) {
+        return res.status(400).json({ err: 'body.priority is required and needs to be a number ' });
+      }
       Logger.verbose('Updating priority of land request', {
         namespace: 'routes:api:priority',
         requestId,
@@ -330,7 +333,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       if (success) {
         res.json({ message: 'Updated priority of request' });
       } else {
-        res.status(404).json({ error: 'Request does not exist' });
+        res.status(404).json({ error: 'Land request does not exist' });
       }
     }),
   );

--- a/src/static/current-state/components/App.tsx
+++ b/src/static/current-state/components/App.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { RunnerState } from '../../../types';
-import { Section } from './Section';
 import { WithAPIData } from './WithAPIData';
 import { CurrentState } from './CurrentState';
 import { RunningBuilds } from './RunningBuilds';
@@ -12,7 +11,7 @@ export const App: React.FunctionComponent = () => (
     <WithAPIData<{ loggedIn: boolean; user?: ISessionUser; permission: IPermissionMode }>
       endpoint="auth/whoami"
       renderLoading={() => <Header />}
-      render={userInfo => {
+      render={(userInfo) => {
         if (userInfo.loggedIn) {
           const loggedInUser = { ...userInfo.user!, permission: userInfo.permission };
           return (
@@ -21,11 +20,14 @@ export const App: React.FunctionComponent = () => (
               <WithAPIData<RunnerState>
                 poll={true}
                 endpoint="api/current-state"
-                renderLoading={() => <Section>Loading...</Section>}
-                render={data => (
+                render={(data, refresh) => (
                   <div>
                     <CurrentState {...data} />
-                    <RunningBuilds queue={data.queue} bitbucketBaseUrl={data.bitbucketBaseUrl} />
+                    <RunningBuilds
+                      queue={data.queue}
+                      bitbucketBaseUrl={data.bitbucketBaseUrl}
+                      refreshData={refresh}
+                    />
                     <Tabs
                       bitbucketBaseUrl={data.bitbucketBaseUrl}
                       selected={1}
@@ -35,6 +37,7 @@ export const App: React.FunctionComponent = () => (
                       paused={data.pauseState !== null}
                       bannerMessageState={data.bannerMessageState}
                       permissionsMessage={data.permissionsMessage}
+                      refreshData={refresh}
                     />
                   </div>
                 )}

--- a/src/static/current-state/components/QueueItemsList.tsx
+++ b/src/static/current-state/components/QueueItemsList.tsx
@@ -21,11 +21,12 @@ export type QueueItemsListProps = {
   renderEmpty?: () => JSX.Element;
   running?: boolean;
   bitbucketBaseUrl: string;
+  refreshData: () => void;
 };
 
-export const QueueItemsList: React.FunctionComponent<QueueItemsListProps> = props => {
-  const { queue, fading, renderEmpty, running } = props;
-  const filteredQueue = queue.filter(item => running || item.state === 'queued');
+export const QueueItemsList: React.FunctionComponent<QueueItemsListProps> = (props) => {
+  const { queue, fading, renderEmpty, running, refreshData } = props;
+  const filteredQueue = queue.filter((item) => running || item.state === 'queued');
   if (!filteredQueue.length) {
     return renderEmpty ? renderEmpty() : <EmptyState>Empty...</EmptyState>;
   }
@@ -39,6 +40,7 @@ export const QueueItemsList: React.FunctionComponent<QueueItemsListProps> = prop
             status={item}
             key={item.requestId}
             queue={queue}
+            refreshData={refreshData}
           />
         ) : (
           <QueueItemJoined
@@ -46,6 +48,7 @@ export const QueueItemsList: React.FunctionComponent<QueueItemsListProps> = prop
             status={item}
             key={item.requestId}
             queue={queue}
+            refreshData={refreshData}
           />
         ),
       )}

--- a/src/static/current-state/components/RunningBuilds.tsx
+++ b/src/static/current-state/components/RunningBuilds.tsx
@@ -5,13 +5,16 @@ import { QueueItemsList } from './QueueItemsList';
 export type Props = {
   queue: IStatusUpdate[];
   bitbucketBaseUrl: string;
+  refreshData: () => void;
 };
 
 function findRunning(updates: IStatusUpdate[]) {
-  return updates.filter(update => ['running', 'awaiting-merge', 'merging'].includes(update.state));
+  return updates.filter((update) =>
+    ['running', 'awaiting-merge', 'merging'].includes(update.state),
+  );
 }
 
-export const RunningBuilds: React.FunctionComponent<Props> = props => {
+export const RunningBuilds: React.FunctionComponent<Props> = (props) => {
   const running = findRunning(props.queue);
 
   if (running.length === 0) {
@@ -23,7 +26,7 @@ export const RunningBuilds: React.FunctionComponent<Props> = props => {
   }
 
   const groupedByTargetBranch: { [branch: string]: IStatusUpdate[] } = {};
-  running.forEach(item => {
+  running.forEach((item) => {
     const targetBranch = item.request.pullRequest.targetBranch || item.requestId;
     if (!groupedByTargetBranch[targetBranch]) {
       groupedByTargetBranch[targetBranch] = [item];
@@ -35,11 +38,12 @@ export const RunningBuilds: React.FunctionComponent<Props> = props => {
   return (
     <Section>
       <h3>Running Builds</h3>
-      {Object.keys(groupedByTargetBranch).map(branch => (
+      {Object.keys(groupedByTargetBranch).map((branch) => (
         <div style={{ paddingTop: '27px' }}>
           <QueueItemsList
             bitbucketBaseUrl={props.bitbucketBaseUrl}
             queue={groupedByTargetBranch[branch]}
+            refreshData={props.refreshData}
             running
           />
         </div>

--- a/src/static/current-state/components/WithAPIData.tsx
+++ b/src/static/current-state/components/WithAPIData.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
+import { Section } from './Section';
 
 const DEFAULT_POLLING_INTERVAL = 15 * 1000; // 15 sec
 
-const defaultLoading = () => <div>Loading...</div>;
+const defaultLoading = () => <Section>Loading...</Section>;
 
 export type Props<D> = {
   endpoint: string;
   poll?: number | boolean;
-  renderError?: (err: Error) => React.ReactNode;
+  renderError?: (err: Error, refresh: () => void) => React.ReactNode;
   renderLoading?: () => React.ReactNode;
-  render?: (data: D) => React.ReactNode;
+  render?: (data: D, refresh: () => void) => React.ReactNode;
 };
 
 export type State = {
@@ -28,9 +29,9 @@ export class WithAPIData<T> extends React.Component<Props<T>, State> {
 
   fetchData() {
     fetch(`/${this.props.endpoint}`)
-      .then(res => res.json())
-      .then(data => this.setState({ data }))
-      .catch(error => this.setState({ error }));
+      .then((res) => res.json())
+      .then((data) => this.setState({ data }))
+      .catch((error) => this.setState({ error }));
   }
 
   componentDidMount() {
@@ -63,9 +64,9 @@ export class WithAPIData<T> extends React.Component<Props<T>, State> {
     let { renderError, render, renderLoading } = this.props;
 
     if (error) {
-      return renderError ? renderError(error) : null;
+      return renderError ? renderError(error, this.fetchData.bind(this)) : null;
     } else if (data) {
-      return render ? render(data) : null;
+      return render ? render(data, this.fetchData.bind(this)) : null;
     }
 
     return renderLoading ? renderLoading() : defaultLoading();

--- a/src/static/current-state/components/tabs/HistoryTab.tsx
+++ b/src/static/current-state/components/tabs/HistoryTab.tsx
@@ -5,7 +5,6 @@ import { TabContent } from './TabContent';
 import { EmptyState } from '../EmptyState';
 import { QueueItemJoined } from '../QueueItem';
 import { WithAPIData } from '../WithAPIData';
-import { Section } from '../Section';
 
 // export type HistoryItemsListProps = {
 //   history: Array<HistoryItem>;
@@ -56,9 +55,8 @@ export class HistoryTab extends React.Component<HistoryTabProps, HistoryState> {
     return (
       <WithAPIData<HistoryResponse>
         poll={false}
-        renderLoading={() => <Section>Loading...</Section>}
         endpoint={`api/history?page=${this.state.page}`}
-        render={historyResponse => {
+        render={(historyResponse, refresh) => {
           const { history, pageLen, count } = historyResponse;
           if (history === undefined || !history.length) {
             return (
@@ -76,12 +74,13 @@ export class HistoryTab extends React.Component<HistoryTabProps, HistoryState> {
 
           return (
             <div>
-              {history.map(item => (
+              {history.map((item) => (
                 <QueueItemJoined
                   bitbucketBaseUrl={this.props.bitbucketBaseUrl}
                   status={item}
                   key={item.request.id}
                   queue={history}
+                  refreshData={refresh}
                 />
               ))}
               <div style={{ marginTop: '30px' }}>

--- a/src/static/current-state/components/tabs/Messenger.tsx
+++ b/src/static/current-state/components/tabs/Messenger.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 export type MessengerProps = {
   bannerMessageState: IMessageState | null;
+  refreshData: () => void;
 };
 
 type MessengerState = {
@@ -28,17 +29,19 @@ export class Messenger extends React.Component<MessengerProps, MessengerState> {
   };
 
   sendMessage = () => {
+    const { refreshData } = this.props;
     const { message, type } = this.state;
     if (!message) return;
     fetch('/api/message', {
       method: 'POST',
       headers: new Headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({ message, type }),
-    }).then(() => location.reload());
+    }).then(() => refreshData());
   };
 
   removeMessage = () => {
-    fetch('/api/remove-message', { method: 'POST' }).then(() => location.reload());
+    const { refreshData } = this.props;
+    fetch('/api/remove-message', { method: 'POST' }).then(() => refreshData());
   };
 
   render() {
@@ -100,9 +103,7 @@ export class Messenger extends React.Component<MessengerProps, MessengerState> {
                 fontWeight: msgType === 'default' ? 'bold' : 'normal',
               }}
             >
-              {`${this.messageEmoji[msgType]} ${bannerMessageState.message} ${
-                this.messageEmoji[msgType]
-              }`}
+              {`${this.messageEmoji[msgType]} ${bannerMessageState.message} ${this.messageEmoji[msgType]}`}
             </div>
             <button
               className="ak-button ak-button__appearance-default"

--- a/src/static/current-state/components/tabs/QueueTab.tsx
+++ b/src/static/current-state/components/tabs/QueueTab.tsx
@@ -8,10 +8,11 @@ export type QueueTabProps = {
   loggedInUser: ISessionUser;
   queue: IStatusUpdate[];
   permissionsMessage: string;
+  refreshData: () => void;
 };
 
-export const QueueTab: React.FunctionComponent<QueueTabProps> = props => {
-  const { bitbucketBaseUrl, loggedInUser, queue, permissionsMessage } = props;
+export const QueueTab: React.FunctionComponent<QueueTabProps> = (props) => {
+  const { bitbucketBaseUrl, loggedInUser, queue, permissionsMessage, refreshData } = props;
   return (
     <div>
       <QueueItemsList
@@ -25,6 +26,7 @@ export const QueueTab: React.FunctionComponent<QueueTabProps> = props => {
             </EmptyState>
           </TabContent>
         )}
+        refreshData={refreshData}
       />
     </div>
   );

--- a/src/static/current-state/components/tabs/SystemTab.tsx
+++ b/src/static/current-state/components/tabs/SystemTab.tsx
@@ -8,6 +8,7 @@ export type SystemTabProps = {
   loggedInUser: ISessionUser;
   defaultPaused: boolean;
   bannerMessageState: IMessageState | null;
+  refreshData: () => void;
 };
 
 export type SystemTabsState = {
@@ -23,6 +24,7 @@ export class SystemTab extends React.Component<SystemTabProps, SystemTabsState> 
   }
 
   handlePauseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { refreshData } = this.props;
     const checked = e.target.checked;
     if (checked) {
       const reason = window.prompt(
@@ -36,31 +38,32 @@ export class SystemTab extends React.Component<SystemTabProps, SystemTabsState> 
         body: JSON.stringify({ reason }),
       }).then(() => {
         this.setState({ paused: true });
-        location.reload();
+        refreshData();
       });
     } else {
       fetch('/api/unpause', { method: 'POST' }).then(() => {
         this.setState({ paused: false });
-        location.reload();
+        refreshData();
       });
     }
   };
 
   handleNextClick = () => {
+    const { refreshData } = this.props;
     fetch('/api/next', { method: 'POST' })
-      .then(response => response.json())
-      .then(json => {
+      .then((response) => response.json())
+      .then((json) => {
         if (json.error) {
           console.error(json.error);
           window.alert(json.error);
         } else {
-          location.reload();
+          refreshData();
         }
       });
   };
 
   render() {
-    const { users, loggedInUser, bannerMessageState } = this.props;
+    const { users, loggedInUser, bannerMessageState, refreshData } = this.props;
     return (
       <TabContent>
         <div style={{ marginTop: '27px' }}>
@@ -96,7 +99,7 @@ export class SystemTab extends React.Component<SystemTabProps, SystemTabsState> 
                   Next Build
                 </button>
               </div>
-              <Messenger bannerMessageState={bannerMessageState} />
+              <Messenger bannerMessageState={bannerMessageState} refreshData={refreshData} />
             </React.Fragment>
           )}
           <UsersList users={users} loggedInUser={loggedInUser} />

--- a/src/static/current-state/components/tabs/index.tsx
+++ b/src/static/current-state/components/tabs/index.tsx
@@ -50,7 +50,7 @@ export type TabsControlsProps = {
   selectTab: (tab: number) => void;
 };
 
-const TabsControls: React.FunctionComponent<TabsControlsProps> = props => {
+const TabsControls: React.FunctionComponent<TabsControlsProps> = (props) => {
   const { selected, selectTab } = props;
   return (
     <div className={controlsStyles}>
@@ -85,6 +85,7 @@ export type TabsProps = {
   paused: boolean;
   bannerMessageState: IMessageState | null;
   permissionsMessage: string;
+  refreshData: () => void;
 };
 
 type TabsState = {
@@ -121,6 +122,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
       paused,
       bannerMessageState,
       permissionsMessage,
+      refreshData,
     } = this.props;
 
     return (
@@ -132,6 +134,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
             loggedInUser={loggedInUser}
             defaultPaused={paused}
             bannerMessageState={bannerMessageState}
+            refreshData={refreshData}
           />
         ) : null}
         {selected === 1 ? (
@@ -140,6 +143,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
             loggedInUser={loggedInUser}
             queue={queue}
             permissionsMessage={permissionsMessage}
+            refreshData={refreshData}
           />
         ) : null}
         {selected === 2 ? (

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -26,6 +26,7 @@ declare interface ILandRequest {
   created: Date;
   pullRequest: IPullRequest;
   dependsOn: string | null;
+  priority: number | null;
 }
 
 declare interface IPullRequest {

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,17 +937,17 @@
   integrity sha1-8Owl2/Lw5LGGRzE6wDETTKWySyE=
 
 "@types/mongodb@*":
-  version "3.6.14"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/mongodb/-/mongodb-3.6.14.tgz#5ffb28d2913a5e1b089956af1fe7d7d67f0702f9"
-  integrity sha1-X/so0pE6XhsImVavH+fX1n8HAvk=
+  version "3.6.15"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/mongodb/-/mongodb-3.6.15.tgz#a2fb99bf14bebbccbd5452449b3409e38a902f88"
+  integrity sha1-ovuZvxS+u8y9VFJEmzQJ44qQL4g=
   dependencies:
     "@types/bson" "*"
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^15.0.2":
-  version "15.3.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
-  integrity sha1-1v7X1rxoVDBto96hr5+HSwB4PiY=
+  version "15.3.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/node/-/node-15.3.1.tgz#23a06b87eedb524016616e886b116b8fdcb180af"
+  integrity sha1-I6Brh+7bUkAWYW6IaxFrj9yxgK8=
 
 "@types/node@11.12.2":
   version "11.12.2"
@@ -2584,6 +2584,11 @@ cookie@0.4.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=
 
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha1-r9cT/ibr0hupXOth+agRblClN9E=
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -3200,9 +3205,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.723:
-  version "1.3.731"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/electron-to-chromium/-/electron-to-chromium-1.3.731.tgz#9f17f7e16f798eaddb21409d80aa755b5b5053dc"
-  integrity sha1-nxf34W95jq3bIUCdgKp1W1tQU9w=
+  version "1.3.735"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/electron-to-chromium/-/electron-to-chromium-1.3.735.tgz#fa1a8660f2790662291cb2136f0e446a444cdfdc"
+  integrity sha1-+hqGYPJ5BmIpHLITbw5EakRM39w=
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3560,17 +3565,17 @@ expect@^25.5.0:
     jest-regex-util "^25.2.6"
 
 express-session@^1.17.1:
-  version "1.17.1"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/express-session/-/express-session-1.17.1.tgz#36ecbc7034566d38c8509885c044d461c11bf357"
-  integrity sha1-Nuy8cDRWbTjIUJiFwETUYcEb81c=
+  version "1.17.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/express-session/-/express-session-1.17.2.tgz#397020374f9bf7997f891b85ea338767b30d0efd"
+  integrity sha1-OXAgN0+b95l/iRuF6jOHZ7MNDv0=
   dependencies:
-    cookie "0.4.0"
+    cookie "0.4.1"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "~2.0.0"
     on-headers "~1.0.2"
     parseurl "~1.3.3"
-    safe-buffer "5.2.0"
+    safe-buffer "5.2.1"
     uid-safe "~2.1.5"
 
 express-winston@^3.0.1:
@@ -7285,10 +7290,10 @@ prepend-http@^1.0.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.8.2:
-  version "1.19.1"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=
+prettier@^2.3.0:
+  version "2.3.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
+  integrity sha1-tqW/EoQCauZA8X9/9WWKdWf8DRg=
 
 pretty-bytes@^5.3.0:
   version "5.6.0"
@@ -7979,12 +7984,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha1-mR7GnSluAxN0fVm9/St0XDX4go0=
 
-safe-buffer@5.2.0:
-  version "5.2.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=
-
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=


### PR DESCRIPTION
Just a simple numeric priority system, stored in the request table so it can persist between queue statuses if something re-queues due to a failed dependency.

Admins can increment and decrement based on the importance of a PR, and requests will be bumped every time they re-queue so that merge times are decreased for PRs unfairly effected by other PRs.