### PR TITLE
Remove unnecessary increment priority button

### DIFF
--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -333,16 +333,6 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
               >
                 Remove
               </button>
-              <button
-                className="queue-item__button"
-                onClick={() =>
-                  this.handleAdminControlClick(ADMIN_CONTROLS.PRIORITY, {
-                    priority: (status.request.priority ?? 0) + 1,
-                  })
-                }
-              >
-                Increment priority
-              </button>
             </StatusItem>
           </div>
         ) : null}


### PR DESCRIPTION
Don't know how I didn't notice this but the button I was using to test the API was left in after I added in the real buttons.