### PR TITLE
path-parse bump and use debian:10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:12-buster-slim
 
 WORKDIR /opt/service
 
@@ -20,7 +20,7 @@ COPY webpack.*.js README.md /opt/service/
 COPY tools /opt/service/tools
 
 # Install dependencies
-RUN yarn --cache-folder ../ycach && NODE_ENV=production yarn build && yarn --production --cache-folder ../ycache && rm -rf ../ycache && rm -rf src && rm -rf typings
+RUN yarn --cache-folder ../ycach && NODE_ENV=production yarn build && yarn --production --cache-folder ../ycache && rm -rf ../ycache && rm -rf src && rm -rf tools && rm -rf typings
 
 ENV NODE_ENV=production
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
   "resolutions": {
     "lodash": "^4.17.21",
     "color-string": "^1.5.5",
-    "@types/sequelize": "^4.28.9"
+    "@types/sequelize": "^4.28.9",
+    "path-parse": "^1.0.7"
   },
   "lint-staged": {
     "*.js": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7089,10 +7089,10 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=
 
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=
+path-parse@^1.0.6, path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=
 
 path-to-regexp@0.1.7:
   version "0.1.7"


### PR DESCRIPTION
Resolve path-parse to secure version and use `node:12-buster-slim` base image which uses `debian:10` instead of `debian:9`.