### PR TITLE
AFP-3081 Upgrade & pin node version at 12.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster-slim
+FROM node:12.22.3-buster-slim
 
 WORKDIR /opt/service
 


### PR DESCRIPTION
Upgrades from Node `12.22.1` to `12.22.3` and pins it to that exact version for deterministic results on rebuilds