### PR TITLE
Update docker image version to avoid vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.3-buster-slim
+FROM node:12.22.6-buster-slim
 
 WORKDIR /opt/service
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Integration Testing for Landkid
 
-This document describes how to run the integration tests for Landkid on dev instance.
+This document describes how to run the integration tests for Landkid on the dev instance.
 
 The integration tests for Landkid are setup to target a Bitbucket repository, only available to Atlassian employees.
 
@@ -10,7 +10,7 @@ Developers would need to run the tests locally to validate their changes.
 
 ## Deploy to dev instance
 
-For testing purposes, we recommend to use the [dev](https://atlassian-frontend-landkid.dev.services.atlassian.com/current-state/) instance.
+For testing purposes, we recommend using the [dev](https://atlassian-frontend-landkid.dev.services.atlassian.com/current-state/) instance.
 
 (For strict local dev loop, see this [document](https://bitbucket.org/atlassian/atlassian-frontend-landkid-deployment/src/master/development.md) )
 
@@ -27,15 +27,17 @@ For testing purposes, we recommend to use the [dev](https://atlassian-frontend-l
 
 In this repository:
 
-1. Create your own copy of `cypress.env.json` - the file is `.gitignore` but maake sure it is not committed by mistake.
+1. Create your own copy of `cypress.env.json` - the file is `.gitignore` but make sure it is not committed by mistake.
 2. Ask access to the folder `Landkid credentials for testing` in LastPass
-3. Fill the environment variables required
+3. Fill out the environment variables required
 
 ```
 {
     "BITBUCKET_APP_PASSWORD": "bitbucket app password",
-    "LANDKID_SESSION_ID": "landkid.sid cookie from https://atlassian-frontend-landkid.dev.services.atlassian.com/current-state/",
-    "CUSTOM_TOKEN": "token for specific endpoints"
+    "LANDKID_SESSION_ID": "landkid.sid cookie from https://atlassian-frontend-landkid.dev.services.atlassian.com/current-state/, this is used by circleCI",
+    "LANDKID_DEV_SESSION_ID"; "this is used in the local dev loop, use the LANDKID_SESSION_ID value to test a dev deployment locally otherwise use the landkid.sid cookie in your local instance of landkid",
+    "LANDKID_DEV_URL": "https://atlassian-frontend-landkid.dev.services.atlassian.com/current-state/ to test a dev deployment or https://[basurl]/current-state for local testing",
+    "CUSTOM_TOKEN": "token for specific endpoints - use the HASHED_CUSTOM_TOKEN"
 }
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,10 +2,11 @@
 
 This document describes how to run the integration tests for Landkid on dev instance.
 
-Currently, those integration tests cannot run in CircleCI because they try to use a Bitbucket repository that is now only accessible through VPN.
+The integration tests for Landkid are setup to target a Bitbucket repository, only available to Atlassian employees.
+
+Currently, those integration tests cannot run in CircleCI because the Bitbucket repository they access is only accessible through VPN.
 
 Developers would need to run the tests locally to validate their changes.
-
 
 ## Deploy to dev instance
 
@@ -14,6 +15,7 @@ For testing purposes, we recommend to use the [dev](https://atlassian-frontend-l
 (For strict local dev loop, see this [document](https://bitbucket.org/atlassian/atlassian-frontend-landkid-deployment/src/master/development.md) )
 
 ### Workflow
+
 1. Push your changes to CircleCI
 2. Grab the image number from the `publish` step in CircleCI build from your PR in GitHub - for example: https://app.circleci.com/pipelines/github/atlassian/landkid/396/workflows/4445d64a-b96d-4f2c-bec4-f0d8d4a6b251/jobs/1499 -> `circle-1499`
 3. Access the [atlassian-frontend-landkid-deployment repository](https://bitbucket.org/atlassian/atlassian-frontend-landkid-deployment/src/master/)
@@ -24,9 +26,11 @@ For testing purposes, we recommend to use the [dev](https://atlassian-frontend-l
 ## Setup environment variables
 
 In this repository:
+
 1. Create your own copy of `cypress.env.json` - the file is `.gitignore` but maake sure it is not committed by mistake.
 2. Ask access to the folder `Landkid credentials for testing` in LastPass
 3. Fill the environment variables required
+
 ```
 {
     "BITBUCKET_APP_PASSWORD": "bitbucket app password",


### PR DESCRIPTION
Update node docker image version to 12.22.6 to avoid vulnerability 

Integration tests: 
![image](https://user-images.githubusercontent.com/51809771/133246997-0deef4d7-d15a-4041-b4f6-23f2c56efc54.png)

