### PR TITLE
add workaround for getting task count

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -134,6 +134,16 @@ export class BitbucketAPI {
     return this.bitbucketMerger.cancelMergePolling(prId);
   };
 
+  getTaskCount = async (pullRequestId: number) => {
+    const endpoint = `${this.baseUrl}/pullrequests/${pullRequestId}/tasks`;
+    const resp = await axios.get<BB.PullRequestTaskResponse>(
+      endpoint,
+      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+    );
+    const data = resp.data;
+    return data.values.filter((task) => task.state === 'UNRESOLVED').length;
+  };
+
   getPullRequest = async (pullRequestId: number): Promise<BB.PullRequest> => {
     const endpoint = `${this.baseUrl}/pullrequests/${pullRequestId}`;
     const resp = await axios.get<BB.PullRequestResponse>(
@@ -142,8 +152,8 @@ export class BitbucketAPI {
     );
     const data = resp.data;
     const approvals = data.participants
-      .filter(participant => participant.approved)
-      .map(participant => participant.user.account_id);
+      .filter((participant) => participant.approved)
+      .map((participant) => participant.user.account_id);
 
     return {
       pullRequestId,
@@ -157,7 +167,7 @@ export class BitbucketAPI {
       state: data.state,
       sourceBranch: data.source.branch.name,
       approvals: approvals,
-      openTasks: data.task_count,
+      openTasks: await this.getTaskCount(pullRequestId),
     };
   };
 
@@ -171,8 +181,8 @@ export class BitbucketAPI {
     const allBuildStatuses = resp.data.values;
     // need to remove build statuses that we created or rerunning would be impossible
     return allBuildStatuses
-      .filter(buildStatus => !buildStatus.name.match(/Pipeline #.+? for landkid/))
-      .map(status => ({
+      .filter((buildStatus) => !buildStatus.name.match(/Pipeline #.+? for landkid/))
+      .map((status) => ({
         name: status.name,
         state: status.state,
         createdOn: new Date(status.created_on),

--- a/src/bitbucket/types.d.ts
+++ b/src/bitbucket/types.d.ts
@@ -40,6 +40,17 @@ declare namespace BB {
     task_count: number;
   };
 
+  type PullRequestTaskResponse = {
+    pagelen: number;
+    values: [
+      {
+        state: string;
+      },
+    ];
+    page: number;
+    size: number;
+  };
+
   type BuildStatusResponse = {
     name: string;
     state: BuildState;

--- a/tests/unit/BitbucketAPI.test.ts
+++ b/tests/unit/BitbucketAPI.test.ts
@@ -4,7 +4,7 @@ import { BitbucketAPI } from '../../src/bitbucket/BitbucketAPI';
 import { MergeOptions } from '../../src/types';
 
 jest.mock('axios');
-const mockedAxios = (axios as unknown) as jest.Mocked<typeof axios>;
+const mockedAxios = axios as unknown as jest.Mocked<typeof axios>;
 
 jest.mock('delay');
 
@@ -86,5 +86,24 @@ describe('mergePullRequest', () => {
         commitMessage: expect.stringContaining('[skip ci]'),
       }),
     );
+  });
+
+  test('Get task count, should call API and return the correct number of tasks UNRESOLVED', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        values: [
+          {
+            state: 'RESOLVED',
+          },
+          {
+            state: 'UNRESOLVED',
+          },
+        ],
+        page: 1,
+        size: 2,
+      },
+    });
+    const taskCount = await bitbucketAPI.getTaskCount(1);
+    expect(taskCount).toEqual(1);
   });
 });


### PR DESCRIPTION
This change introduces a workaround for an issue where bitbucket returns a task_count of 0 when calling the pull_request API. We can instead directly call the /tasks endpoint, which returns the correct data.

This fix will unblock https://hello.atlassian.net/browse/EXPAND-1437
The bitbucket bug is tracked https://softwareteams.atlassian.net/browse/COREX-4320