### PR TITLE
Give authenticated users land rights by default

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -241,7 +241,7 @@ export class Permission extends Model<Permission> implements IPermission {
   readonly aaid: string;
 
   @AllowNull(false)
-  @Default('read')
+  @Default('land')
   @Column(Sequelize.ENUM({ values: ['read', 'land', 'admin'] }))
   readonly mode: IPermissionMode;
 

--- a/src/lib/PermissionService.ts
+++ b/src/lib/PermissionService.ts
@@ -12,7 +12,7 @@ class PermissionService {
     });
 
     if (!permission) {
-      const defaultMode: IPermissionMode = config.landkidAdmins.includes(aaid) ? 'admin' : 'read';
+      const defaultMode: IPermissionMode = config.landkidAdmins.includes(aaid) ? 'admin' : 'land';
       Logger.info('User does not exist, creating one', {
         namespace: 'lib:permissions:getPermissionForUser',
         defaultMode,


### PR DESCRIPTION
This needs to be combined with an update to the Landkid deployment repositories, so Landkid is deployed behind the VPN.