### PR TITLE
when paused, disallow land requests to move to running

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -68,6 +68,7 @@ export class Runner {
   };
 
   moveFromQueueToRunning = async (landRequestStatus: LandRequestStatus, lockId: Date) => {
+    if (await this.getPauseState()) return;
     const landRequest = landRequestStatus.request;
     const running = await this.getRunning();
     const runningTargetingSameBranch = running.filter(


### PR DESCRIPTION
land requests won't move from queued to running when paused