### PR TITLE
External link fix

### DIFF
--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -58,6 +58,20 @@ type MessageProps = {
   } | null;
 };
 
+/**
+ * Have to override SectionMessageAction link component because
+ * it doesn't support `target`. Without using `target="_blank"`
+ * the link to Landkid home page would load within the Bitbucket
+ * addon <iframe>
+ */
+const ExternalLink = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <a href="/" target="_blank">
+      {children}
+    </a>
+  );
+};
+
 const Message = ({
   loading,
   appName,
@@ -141,7 +155,9 @@ const Message = ({
                 </SectionMessageAction>,
               ]
             : []),
-          <SectionMessageAction href="/">Learn about Landkid</SectionMessageAction>,
+          <SectionMessageAction href="/" linkComponent={ExternalLink}>
+            Learn about Landkid
+          </SectionMessageAction>,
         ]}
       >
         {renderLandState()}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true
   },
-  "exclude": ["node_modules", "tests", "*.stories.*"],
+  "exclude": ["node_modules", "tests", "**/*.stories.tsx"],
 }


### PR DESCRIPTION
Fixes a bug where the home page opens within the Bitbucket addon iframe when clicking "Learn more about Landkid"

![landkid-home](https://user-images.githubusercontent.com/8190792/187630119-8b6384c0-cd25-4c3e-a63f-f13cc5837dd9.png)

Also fixes a bug where Storybook files were being emitted. Thought this was fixed previously, but the pattern was incorrect.