### PR TITLE
Server auth fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "webpack-dev-server": "^4.10.1"
   },
   "dependencies": {
-    "@atlaskit/button": "^16.3.6",
+    "@atlaskit/button": "^15.0.0",
     "@atlaskit/css-reset": "^6.3.13",
     "@atlaskit/pagination": "^8.0.5",
     "@atlaskit/section-message": "^6.1.12",
@@ -118,7 +118,7 @@
     "sequelize": "^4.44.0",
     "sequelize-typescript": "^0.6.6",
     "styled-components": "^3.2.6",
-    "typescript": "^4.2.4",
+    "typescript": "4.3.5",
     "ua-parser-js": "^0.7.24",
     "umzug": "^2.2.0",
     "winston": "^3.1.0"

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
-import * as jwtTools from 'atlassian-jwt';
+import { fromMethodAndUrl } from 'atlassian-jwt';
 
 import { MergeOptions, RepoConfig } from '../types';
 import { Logger } from '../lib/Logger';
@@ -138,7 +138,7 @@ export class BitbucketAPI {
     const endpoint = `${this.baseUrl}/pullrequests/${pullRequestId}/tasks`;
     const resp = await axios.get<BB.PullRequestTaskResponse>(
       endpoint,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
     );
     const data = resp.data;
     return data.values.filter((task) => task.state === 'UNRESOLVED').length;
@@ -148,7 +148,7 @@ export class BitbucketAPI {
     const endpoint = `${this.baseUrl}/pullrequests/${pullRequestId}`;
     const resp = await axios.get<BB.PullRequestResponse>(
       endpoint,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
     );
     const data = resp.data;
     const approvals = data.participants
@@ -175,7 +175,7 @@ export class BitbucketAPI {
     const endpoint = `${this.baseUrl}/pullrequests/${pullRequestId}/statuses`;
     const resp = await axios.get<{ values: BB.BuildStatusResponse[] }>(
       endpoint,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
     );
     // fairly safe to assume we'll never need to paginate these results
     const allBuildStatuses = resp.data.values;
@@ -194,7 +194,7 @@ export class BitbucketAPI {
     const endpoint = `https://api.bitbucket.org/2.0/users/${aaid}`;
     const resp = await axios.get(
       endpoint,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
     );
 
     return {
@@ -213,7 +213,7 @@ export class BitbucketAPI {
     });
     const { data } = await axios.get<BB.RepositoryResponse>(
       endpoint,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', endpoint)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
     );
     Logger.info('successfully fetched repo uuid', {
       namespace: 'bitbucket:api:getRepository',

--- a/src/bitbucket/BitbucketAuthenticator.ts
+++ b/src/bitbucket/BitbucketAuthenticator.ts
@@ -1,4 +1,5 @@
-import jwtTools from 'atlassian-jwt';
+import { encode, createQueryStringHash } from 'atlassian-jwt';
+import type { Request } from 'atlassian-jwt';
 import { AxiosRequestConfig } from 'axios';
 
 import { Installation } from '../db';
@@ -11,13 +12,13 @@ class BitbucketAuthenticator {
     return {};
   };
 
-  private getJWTAuthHeaders = (request: jwtTools.Request, install: Installation) => {
-    const token = jwtTools.encode(
+  private getJWTAuthHeaders = (request: Request, install: Installation) => {
+    const token = encode(
       {
         iss: getAppKey(),
         iat: Date.now(),
         exp: Date.now() + 60000,
-        qsh: jwtTools.createQueryStringHash(request),
+        qsh: createQueryStringHash(request),
         sub: install.clientKey,
       },
       install.sharedSecret,
@@ -29,7 +30,7 @@ class BitbucketAuthenticator {
   };
 
   getAuthConfig = async (
-    request: jwtTools.Request,
+    request: Request,
     baseConfig?: AxiosRequestConfig,
   ): Promise<AxiosRequestConfig> => {
     const install = await Installation.findOne<Installation>();

--- a/src/bitbucket/BitbucketMerger.ts
+++ b/src/bitbucket/BitbucketMerger.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import * as jwtTools from 'atlassian-jwt';
+import { fromMethodAndUrl, fromMethodAndPathAndBody } from 'atlassian-jwt';
 import delay from 'delay';
 
 import { bitbucketAuthenticator, axiosPostConfig } from './BitbucketAuthenticator';
@@ -22,20 +22,17 @@ export class BitbucketMerger {
     return axios.post(
       endpoint,
       JSON.stringify(body),
-      await bitbucketAuthenticator.getAuthConfig(
-        jwtTools.fromMethodAndPathAndBody('post', endpoint, body),
-        {
-          ...axiosPostConfig,
-          validateStatus: () => true,
-        },
-      ),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndPathAndBody('post', endpoint, body), {
+        ...axiosPostConfig,
+        validateStatus: () => true,
+      }),
     );
   };
 
   private pollMergeStatus = async (pollUrl: string) => {
     const res = await axios.get<BB.MergeStatusResponse>(
       pollUrl,
-      await bitbucketAuthenticator.getAuthConfig(jwtTools.fromMethodAndUrl('get', pollUrl)),
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', pollUrl)),
     );
     return res.data;
   };

--- a/src/bitbucket/BitbucketPipelinesAPI.ts
+++ b/src/bitbucket/BitbucketPipelinesAPI.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import * as jwtTools from 'atlassian-jwt';
+import { fromMethodAndPathAndBody, fromMethodAndUrl } from 'atlassian-jwt';
 
 import { Logger } from '../lib/Logger';
 import { RepoConfig } from '../types';
@@ -95,7 +95,7 @@ export class BitbucketPipelinesAPI {
       endpoint,
       JSON.stringify(data),
       await bitbucketAuthenticator.getAuthConfig(
-        jwtTools.fromMethodAndPathAndBody('post', endpoint, data),
+        fromMethodAndPathAndBody('post', endpoint, data),
         axiosPostConfig,
       ),
     );
@@ -131,7 +131,7 @@ export class BitbucketPipelinesAPI {
         endpoint,
         null,
         await bitbucketAuthenticator.getAuthConfig(
-          jwtTools.fromMethodAndUrl('post', endpoint),
+          fromMethodAndUrl('post', endpoint),
           axiosPostConfig,
         ),
       );

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import jwtTools from 'atlassian-jwt';
+import { decode, fromExpressRequest, createQueryStringHash } from 'atlassian-jwt';
 import { Installation } from '../db';
 import { permissionService } from '../lib/PermissionService';
 import { Logger } from '../lib/Logger';
@@ -69,7 +69,7 @@ export const authenticateIncomingBBCall: express.RequestHandler = wrap(async (re
 
   let decoded: any;
   try {
-    decoded = jwtTools.decode(jwt, install.sharedSecret);
+    decoded = decode(jwt, install.sharedSecret);
   } catch (err) {
     Logger.error('Could not validate JWT', {
       namespace: 'routes:middleware:authenticateIncomingBBCall',
@@ -85,7 +85,7 @@ export const authenticateIncomingBBCall: express.RequestHandler = wrap(async (re
     });
   }
 
-  const expectedHash = jwtTools.createQueryStringHash(jwtTools.fromExpressRequest(req));
+  const expectedHash = createQueryStringHash(fromExpressRequest(req));
 
   if (expectedHash !== decoded.qsh) {
     Logger.error('JWT token is valid but not for this request', {

--- a/src/static/bitbucket/components/Message.stories.tsx
+++ b/src/static/bitbucket/components/Message.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Message from './Message';

--- a/tests/integration/utils/index.ts
+++ b/tests/integration/utils/index.ts
@@ -1,19 +1,20 @@
-import Joi from 'joi';
+import { string, array } from 'joi';
+import type { ArraySchema } from 'joi';
 
-const queued = Joi.string().only('queued');
-const running = Joi.string().only('running');
-const merging = Joi.string().only('merging');
-const fail = Joi.string().only('fail');
-const success = Joi.string().only('success');
+const queued = string().only('queued');
+const running = string().only('running');
+const merging = string().only('merging');
+const fail = string().only('fail');
+const success = string().only('success');
 
 const successfulFlow = [queued, running, merging, success];
 const failedFlow = [queued, running, fail];
 const failedDepFlow = [queued, running, fail];
 
-export const successful = Joi.array().ordered(...successfulFlow);
-export const failed = Joi.array().ordered(...failedFlow);
-export const reentryFail = Joi.array().ordered(...failedDepFlow, ...failedFlow);
-export const doubleReentrySuccess = Joi.array().ordered(
+export const successful = array().ordered(...successfulFlow);
+export const failed = array().ordered(...failedFlow);
+export const reentryFail = array().ordered(...failedDepFlow, ...failedFlow);
+export const doubleReentrySuccess = array().ordered(
   ...failedDepFlow,
   ...failedDepFlow,
   ...successfulFlow,
@@ -21,6 +22,6 @@ export const doubleReentrySuccess = Joi.array().ordered(
 
 // Including the `awaiting-merge` status check introduced flakiness
 // because of Bitbucket build times, merge times, and other factors
-export const validate = (statuses: string[], schema: Joi.ArraySchema) => {
+export const validate = (statuses: string[], schema: ArraySchema) => {
   return schema.validate(statuses.filter((status) => status !== 'awaiting-merge'));
 };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,11 +8,14 @@
       "es7"
     ],
     "sourceMap": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noImplicitThis": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "jsx": "react-jsx",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
   },
-  "exclude": ["node_modules", "tests", "**/*.stories.tsx"],
+  "exclude": [
+    "node_modules",
+    "tests",
+    "**/*.stories.tsx"
+  ],
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,22 +18,23 @@ module.exports = {
     filename: '[name]/bundle.[chunkhash].js',
   },
   mode: 'development',
+  ignoreWarnings: [(warning) => true],
   devServer: {
     compress: true,
     historyApiFallback: true,
     // hot: true,
     port: Number(DEV_SERVER_PORT),
-    publicPath: '/',
-    stats: 'errors-only',
     proxy: {
       '/api': `http://localhost:${SERVER_PORT}`,
       '/auth': `http://localhost:${SERVER_PORT}`,
       '/bitbucket': `http://localhost:${SERVER_PORT}`,
       '/ac': `http://localhost:${SERVER_PORT}`,
     },
-    public: fs.existsSync('./config.js')
-      ? require('./config').baseUrl.replace('https://', '')
-      : undefined,
+    client: {
+      webSocketURL: fs.existsSync('./config.js')
+        ? require('./config').baseUrl.replace('https://', '')
+        : undefined,
+    },
   },
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,7 +65,19 @@
     babel-runtime "^6.26.0"
     tslib "^1.8.0"
 
-"@atlaskit/button@^16.3.0", "@atlaskit/button@^16.3.6":
+"@atlaskit/button@^15.0.0":
+  version "15.1.8"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/button/-/button-15.1.8.tgz#b612951bcf140f1763081e7c039310261eb1ab9a"
+  integrity sha512-PtQW72w/T9R+1RyoEHywv/ZOyQ29A1VgPsK72GXoLSLoYqTVh7m0QSDqXkR/iOnJlL8jkNDwG4xeMu+e5vyVgQ==
+  dependencies:
+    "@atlaskit/analytics-next" "^8.2.0"
+    "@atlaskit/ds-lib" "^1.2.0"
+    "@atlaskit/spinner" "^15.0.0"
+    "@atlaskit/theme" "^11.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/core" "^10.0.9"
+
+"@atlaskit/button@^16.3.0":
   version "16.3.6"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/button/-/button-16.3.6.tgz#6a184c4d24818953d4afb7aaca5e6854064ba8ce"
   integrity sha512-sigJimyIvWjRzBdW46oPoyyxDmIWaPi7YtxmWwshld0lxQ9U/HevAA4Jxo7tOoHkaQot4V+yLkVHTuTgaH4OJQ==
@@ -94,6 +106,13 @@
     "@atlaskit/tokens" "^0.10.0"
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
+
+"@atlaskit/ds-lib@^1.2.0":
+  version "1.4.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-1.4.2.tgz#9fd6275c9c0bbbed55547a415563d29bb1395de5"
+  integrity sha512-HcZbjppbWLH6cYyb/fDplUZaWabtM1qdse2zUJaACsGTSCCI1m8+T3dVCYlGn6NtzehqkabEY9DWgK/DlLzNlQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 "@atlaskit/ds-lib@^2.1.0":
   version "2.1.1"
@@ -158,7 +177,7 @@
     babel-runtime "^6.26.0"
     react-transition-group "^2.2.1"
 
-"@atlaskit/spinner@^15.1.0", "@atlaskit/spinner@^15.1.11":
+"@atlaskit/spinner@^15.0.0", "@atlaskit/spinner@^15.1.0", "@atlaskit/spinner@^15.1.11":
   version "15.1.15"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/spinner/-/spinner-15.1.15.tgz#62150611c6ec018001ba775736522a7601ce3156"
   integrity sha512-wItnN7hR2OnGoI/q0H8nznStDTYHTMRrvtAuKbMZQ5n/vclrpptuAYTAVFFnzMtue8vo6lFp0+4JYiZY1HSV8w==
@@ -167,6 +186,16 @@
     "@atlaskit/tokens" "^0.10.0"
     "@babel/runtime" "^7.0.0"
     "@emotion/core" "^10.0.9"
+
+"@atlaskit/theme@^11.3.0":
+  version "11.5.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-11.5.2.tgz#43ac3b3a203241ae83b1d62d15912e6c36f465a9"
+  integrity sha512-iycVcMzGaPboTVu0s+DoeV3oZZGIxXca1IjVtlxERA/78dftYoVTjiBnh6XtAQnIgB0O+SaAOQaaHJZgJ4gwpQ==
+  dependencies:
+    "@atlaskit/tokens" "^0.2.0"
+    "@babel/runtime" "^7.0.0"
+    exenv "^1.2.2"
+    prop-types "^15.5.10"
 
 "@atlaskit/theme@^12.1.0":
   version "12.1.10"
@@ -205,6 +234,13 @@
     "@babel/runtime" "^7.0.0"
     "@babel/traverse" "^7.15.0"
     "@babel/types" "^7.15.0"
+
+"@atlaskit/tokens@^0.2.0":
+  version "0.2.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-0.2.1.tgz#85b48d52d49688ebaef604949426588ba9c81892"
+  integrity sha512-Fm/F9mOC7QI5OSwvyY5N5+cvhx0lPLPAE5sE520ztb+YOaSiFxHZ13YBJkkdVTtxbGsYayYWITinGDQcCnhLog==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 "@atlaskit/type-helpers@^2.0.0", "@atlaskit/type-helpers@^2.1.0":
   version "2.1.0"
@@ -14335,10 +14371,10 @@ typedarray@^0.0.6:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.2.4:
-  version "4.8.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 ua-parser-js@^0.7.24, ua-parser-js@^0.7.30:
   version "0.7.31"
@@ -14622,9 +14658,9 @@ url@^0.11.0:
     querystring "0.2.0"
 
 use-memo-one@^1.1.1:
-  version "1.1.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
-  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
+  version "1.1.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Mainly fixes an issue I suspect caused server authentication failures in staging due to a default import mistake from `atlassian-jwt` in `middleware.ts`. I've converted all wildcard imports to be direct.

Also:
- Storybook was no longer loading the `Message` story because of an error with `@atlaskit/button@^16.3.6`. I think the error is related to a missing analytics context provider which is not being used in Landkid. I rolled back to `^15.0.0` before this was required to fix.
- Locked TypeScript version to match AF
- Fixed tsconfig for integration tests. Not sure these are used anyway?
- Updated Webpack devServer config after the Webpack 5 upgrade (does not affect production builds). Should be working again but I can't verify without a valid config.js