### PR TITLE
Open app authorizations page in new tab

### DIFF
--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -103,7 +103,7 @@ const Message = ({
         return (
           <>
             Remove {appName} from the list of denied applications at the bottom of{' '}
-            <a href="https://bitbucket.org/account/settings/app-authorizations/">
+            <a href="https://bitbucket.org/account/settings/app-authorizations/" target="_blank">
               the App authorizations page
             </a>
             , then refresh this page and allow the app to access the required permissions.


### PR DESCRIPTION
Minor bugfix. Prevents the app authorizations page link opening inside the Landkid `<iframe>`, when user is denied access.

![app-auth](https://user-images.githubusercontent.com/8190792/188038037-ddbde523-d7ff-436d-ab23-135e5af51a8a.png)
