### PR TITLE
Enable layered caching of node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apk update && apk upgrade apk-tools
 # Copy PJ, changes should invalidate entire image
 COPY package.json yarn.lock /opt/service/
 
+## Install dependencies
+RUN yarn --cache-folder ../ycache
+
 # Copy commong typings
 COPY typings /opt/service/typings
 
@@ -22,8 +25,14 @@ COPY webpack.*.js README.md /opt/service/
 
 COPY tools /opt/service/tools
 
-# Install dependencies
-RUN yarn --cache-folder ../ycach && NODE_ENV=production yarn build && yarn --production --cache-folder ../ycache && rm -rf ../ycache && rm -rf src && rm -rf tools && rm -rf typings
+# Build
+RUN ls node_modules && NODE_ENV=production yarn build
+
+# Retain only dependencies
+RUN yarn --production --cache-folder ../ycache && rm -rf ../ycache
+
+## Cleanup folders
+RUN rm -rf src && rm -rf tools && rm -rf typings
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Enable docker layered caching to work for node_modules if package.json / yarn.lock are unmodified.