### PR TITLE
Add polling and queue status to landkid widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   "dependencies": {
     "@atlaskit/button": "^15.0.0",
     "@atlaskit/css-reset": "^6.3.13",
-    "@atlaskit/menu": "^1.3.9",
     "@atlaskit/pagination": "^8.0.5",
     "@atlaskit/section-message": "^6.1.12",
     "@atlaskit/spinner": "^15.1.11",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,8 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-dom-confetti": "^0.2.0",
+    "react-intersection-observer": "^9.4.0",
+    "react-usestateref": "^1.0.8",
     "redis": "^3.1.2",
     "redlock": "^3.1.2",
     "reflect-metadata": "^0.1.12",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@atlaskit/button": "^15.0.0",
     "@atlaskit/css-reset": "^6.3.13",
+    "@atlaskit/menu": "^1.3.9",
     "@atlaskit/pagination": "^8.0.5",
     "@atlaskit/section-message": "^6.1.12",
     "@atlaskit/spinner": "^15.1.11",

--- a/src/bitbucket/descriptor.ts
+++ b/src/bitbucket/descriptor.ts
@@ -45,6 +45,9 @@ export const makeDescriptor = () => {
           destination:
             '/bitbucket/proxy/can-land?aaid={user.uuid}&pullRequestId={pullrequest.id}&accountId={user.account_id}&sourceBranch={pullrequest.source.branch.name}&destinationBranch={pullrequest.destination.branch.name}',
         },
+        '/queue': {
+          destination: '/bitbucket/proxy/queue',
+        },
         '/land/{repository}/{pullrequest}': {
           destination:
             '/bitbucket/proxy/land?aaid={user.uuid}&pullRequestId={pullrequest.id}&commit={pullrequest.source.commit.hash}&accountId={user.account_id}',
@@ -64,7 +67,7 @@ export const makeDescriptor = () => {
           name: {
             value: addonName,
           },
-          url: `/bitbucket/index.html?state={pullrequest.state}&repoId={repository.uuid}&pullRequestId={pullrequest.id}&${appNameQueryString}`,
+          url: `/bitbucket/index.html?state={pullrequest.state}&repoId={repository.uuid}&repoName={repository.full_name}&pullRequestId={pullrequest.id}&${appNameQueryString}`,
           location: 'org.bitbucket.pullrequest.overview.informationPanel',
           conditions: [
             {

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -661,6 +661,25 @@ export class Runner {
     return status ? status.date : null;
   };
 
+  getLandRequestStateByPRId = async (pullRequestId: number): Promise<LandRequestStatus | null> => {
+    const landRequestStatus = await LandRequestStatus.findOne<LandRequestStatus>({
+      where: {
+        isLatest: true,
+      },
+      order: [['date', 'DESC']],
+      include: [
+        {
+          model: LandRequest,
+          include: [PullRequest],
+          where: {
+            pullRequestId,
+          },
+        },
+      ],
+    });
+    return landRequestStatus;
+  };
+
   private getUsersPermissions = async (
     requestingUserMode: IPermissionMode,
   ): Promise<UserState[]> => {
@@ -789,8 +808,8 @@ export class Runner {
     };
   }
 
-  getState = async (requestingUser: ISessionUser): Promise<RunnerState> => {
-    const requestingUserMode = await permissionService.getPermissionForUser(requestingUser.aaid);
+  getState = async (aaid: string): Promise<RunnerState> => {
+    const requestingUserMode = await permissionService.getPermissionForUser(aaid);
     const [daysSinceLastFailure, pauseState, queue, users, waitingToQueue, bannerMessageState] =
       await Promise.all([
         this.getDatesSinceLastFailures(),

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -42,7 +42,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     wrap(async (req, res) => {
       try {
         Logger.info('Requesting current state', { namespace: 'routes:api:current-state' });
-        const state = await runner.getState(req.user!);
+        const state = await runner.getState(req.user!.aaid);
         eventEmitter.emit('GET_STATE.SUCCESS');
         res.header('Access-Control-Allow-Origin', '*').json(state);
       } catch {

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -27,12 +27,10 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
       };
       const prId = parseInt(pullRequestId, 10);
       try {
-        const { aaid, pullRequestId, sourceBranch, destinationBranch } = req.query as {
+        const { aaid, pullRequestId } = req.query as {
           aaid: string;
           pullRequestId: string;
           accountId: string;
-          sourceBranch: string;
-          destinationBranch: string;
         };
         const prId = parseInt(pullRequestId, 10);
 
@@ -66,13 +64,11 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
           if (pauseState) {
             errors.push(`Builds have been manually paused: "${pauseState.reason}"`);
           } else {
-            const landChecks = await runner.isAllowedToLand({
-              pullRequestId: prId,
+            const landChecks = await runner.isAllowedToLand(
+              prId,
               permissionLevel,
-              queueFetcher: runner.getWaitingAndQueued,
-              sourceBranch,
-              destinationBranch,
-            });
+              runner.getWaitingAndQueued,
+            );
 
             warnings.push(...landChecks.warnings);
             errors.push(...landChecks.errors);

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -173,12 +173,14 @@ const App = () => {
     setLoadStatus('queuing');
     proxyRequest('/land', 'POST')
       .then(() => {
-        checkQueueStatus();
         setStatus('queued');
+        checkQueueStatus();
+        checkIfAbleToLand();
         console.log('status is queued');
       })
       .catch((err) => {
         checkQueueStatus();
+        checkIfAbleToLand();
         console.error(err);
         setStatus('unknown-error');
       });

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -59,7 +59,6 @@ const App = () => {
     threshold: 0,
     onChange: (inViewUpdated) => {
       inViewRef.current = inViewUpdated;
-      console.log('ref changed', inViewUpdated, !document.hidden);
       if (inViewUpdated && !document.hidden) {
         checkIfAbleToLand();
       }
@@ -89,12 +88,6 @@ const App = () => {
     pollAbleToLand();
 
     document.addEventListener('visibilitychange', () => {
-      console.log(
-        'document visibility changed!',
-        document.visibilityState,
-        inViewRef,
-        inViewRef.current,
-      );
       if (document.visibilityState === 'visible' && inViewRef.current) {
         checkIfAbleToLand();
       }
@@ -123,13 +116,6 @@ const App = () => {
     }
 
     if (loadStatusRef.current === 'loading' || loadStatusRef.current === 'refreshing') return;
-
-    console.log(
-      'called check if able to land',
-      loadStatusRef.current,
-      loadStatusRef.current ? 'loading' : 'refreshing',
-    );
-
     setLoadStatus(loadStatusRef.current === 'not-loaded' ? 'loading' : 'refreshing');
 
     return proxyRequest<CanLandResponse>('/can-land', 'POST')
@@ -176,7 +162,6 @@ const App = () => {
         setStatus('queued');
         checkQueueStatus();
         checkIfAbleToLand();
-        console.log('status is queued');
       })
       .catch((err) => {
         checkQueueStatus();

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useInView } from 'react-intersection-observer';
+import useState from 'react-usestateref';
 
 import '@atlaskit/css-reset';
 
-import { proxyRequest } from '../utils/RequestProxy';
+import { proxyRequest, proxyRequestBare } from '../utils/RequestProxy';
 
 import Message from './Message';
+import Timeout = NodeJS.Timeout;
+import { LoadStatus, QueueResponse, Status } from './types';
 
 type BannerMessage = {
   messageExists: boolean;
@@ -12,24 +16,24 @@ type BannerMessage = {
   messageType: 'default' | 'warning' | 'error';
 };
 
+type LandState =
+  | 'will-queue-when-ready'
+  | 'queued'
+  | 'running'
+  | 'awaiting-merge'
+  | 'merging'
+  | 'success'
+  | 'fail'
+  | 'aborted';
+
 type CanLandResponse = {
   canLand: boolean;
   canLandWhenAble: boolean;
   errors: string[];
   warnings: string[];
   bannerMessage: BannerMessage | null;
+  state: LandState | null;
 };
-
-type Status =
-  | 'checking-can-land'
-  | 'cannot-land'
-  | 'queued'
-  | 'can-land'
-  | 'pr-closed'
-  | 'user-denied-access'
-  | 'unknown-error';
-
-type Loading = 'land' | 'land-when-able';
 
 const initialState: CanLandResponse = {
   canLand: false,
@@ -37,78 +41,167 @@ const initialState: CanLandResponse = {
   errors: [],
   warnings: [],
   bannerMessage: null,
+  state: null,
 };
 
 const qs = new URLSearchParams(window.location.search);
 const appName = qs.get('appName') || 'Landkid';
+const pullRequestId = parseInt(qs.get('pullRequestId') || '');
+const repoName = qs.get('repoName') || '';
 
 const App = () => {
-  const [status, setStatus] = useState<Status>('checking-can-land');
-  const [loading, setLoading] = useState<Loading | undefined>();
+  const [status, setStatus, statusRef] = useState<Status | undefined>();
+  const [queue, setQueue] = useState<QueueResponse['queue'] | undefined>();
+  const [_, setLoadStatus, loadStatusRef] = useState<LoadStatus>('not-loaded');
   const [state, dispatch] = useState(initialState);
 
+  const { ref, inView } = useInView({
+    threshold: 0,
+    onChange: (inViewUpdated) => {
+      inViewRef.current = inViewUpdated;
+      console.log('ref changed', inViewUpdated, !document.hidden);
+      if (inViewUpdated && !document.hidden) {
+        checkIfAbleToLand();
+      }
+    },
+  });
+
+  const inViewRef = useRef(inView);
+  inViewRef.current = inView;
+
+  let refreshTimeoutId: Timeout;
+
+  const pollAbleToLand = () => {
+    const isTabInForeground = !document.hidden;
+    let refreshIntervalMs = inViewRef.current ? 10000 : 20000;
+
+    const checkPromise = isTabInForeground ? checkIfAbleToLand() : Promise.resolve();
+
+    checkPromise.finally(async () => {
+      if (statusRef.current == 'pr-closed') return;
+      refreshTimeoutId = setTimeout(() => {
+        pollAbleToLand();
+      }, refreshIntervalMs);
+    });
+  };
+
   useEffect(() => {
-    const isOpen = qs.get('state') === 'OPEN';
-    if (!isOpen) {
-      return setStatus('pr-closed');
-    }
-    checkIfAbleToLand();
+    pollAbleToLand();
+
+    document.addEventListener('visibilitychange', () => {
+      console.log(
+        'document visibility changed!',
+        document.visibilityState,
+        inViewRef,
+        inViewRef.current,
+      );
+      if (document.visibilityState === 'visible' && inViewRef.current) {
+        checkIfAbleToLand();
+      }
+    });
+
+    return () => {
+      clearTimeout(refreshTimeoutId);
+    };
   }, []);
 
-  const checkIfAbleToLand = () => {
-    proxyRequest<CanLandResponse>('/can-land', 'POST')
-      .then(({ canLand, canLandWhenAble, errors, warnings, bannerMessage }) => {
-        setStatus(canLand ? 'can-land' : 'cannot-land');
+  const checkQueueStatus = () => {
+    proxyRequestBare<any>('/queue', 'POST')
+      .then((res) => {
+        setQueue(res.queue);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  const checkIfAbleToLand = async () => {
+    const isOpen = qs.get('state') === 'OPEN';
+    if (!isOpen) {
+      setStatus('pr-closed');
+      return;
+    }
+
+    if (loadStatusRef.current === 'loading' || loadStatusRef.current === 'refreshing') return;
+
+    console.log(
+      'called check if able to land',
+      loadStatusRef.current,
+      loadStatusRef.current ? 'loading' : 'refreshing',
+    );
+
+    setLoadStatus(loadStatusRef.current === 'not-loaded' ? 'loading' : 'refreshing');
+
+    return proxyRequest<CanLandResponse>('/can-land', 'POST')
+      .then(({ canLand, canLandWhenAble, errors, warnings, bannerMessage, state }) => {
+        switch (state) {
+          case 'running':
+          case 'queued':
+            checkQueueStatus();
+          case 'will-queue-when-ready':
+          case 'awaiting-merge':
+          case 'merging':
+            setStatus(state);
+            break;
+          default:
+            setStatus(canLand ? 'can-land' : 'cannot-land');
+        }
 
         dispatch({
           canLand,
           canLandWhenAble,
+          state,
           errors,
           warnings,
           bannerMessage,
         });
+        setLoadStatus('loaded');
       })
       .catch((err) => {
-        setLoading(undefined);
+        setLoadStatus('loaded');
         console.error(err);
         if (err?.code === 'USER_DENIED_ACCESS' || err?.code === 'USER_ALREADY_DENIED_ACCESS') {
           setStatus('user-denied-access');
         } else {
           setStatus('unknown-error');
         }
+        setLoadStatus('loaded');
       });
   };
 
   const onLandClicked = () => {
-    setLoading('land');
+    setLoadStatus('queuing');
     proxyRequest('/land', 'POST')
       .then(() => {
-        setLoading(undefined);
+        checkQueueStatus();
         setStatus('queued');
+        console.log('status is queued');
       })
       .catch((err) => {
-        setLoading(undefined);
+        checkQueueStatus();
         console.error(err);
         setStatus('unknown-error');
       });
   };
 
   const onLandWhenAbleClicked = () => {
-    setLoading('land-when-able');
+    setLoadStatus('queuing');
     proxyRequest('/land-when-able', 'POST')
       .then(() => {
-        setLoading(undefined);
-        setStatus('queued');
+        setStatus('will-queue-when-ready');
+        setLoadStatus('loaded');
+        checkIfAbleToLand();
       })
       .catch((err) => {
-        setLoading(undefined);
+        setStatus('will-queue-when-ready');
+        setLoadStatus('loaded');
         console.error(err);
         setStatus('unknown-error');
       });
   };
 
   const onCheckAgainClicked = () => {
-    setStatus('checking-can-land');
+    setLoadStatus('not-loaded');
     checkIfAbleToLand();
   };
 
@@ -117,10 +210,12 @@ const App = () => {
       style={{
         paddingBottom: 20,
       }}
+      ref={ref}
     >
       <Message
-        loading={loading}
+        loadStatus={loadStatusRef.current}
         appName={appName}
+        queue={queue}
         status={status}
         canLandWhenAble={state.canLandWhenAble}
         errors={state.errors}
@@ -129,6 +224,8 @@ const App = () => {
         onCheckAgainClicked={onCheckAgainClicked}
         onLandWhenAbleClicked={onLandWhenAbleClicked}
         onLandClicked={onLandClicked}
+        pullRequestId={pullRequestId}
+        repoName={repoName}
       />
     </div>
   );

--- a/src/static/bitbucket/components/Message.stories.tsx
+++ b/src/static/bitbucket/components/Message.stories.tsx
@@ -22,10 +22,54 @@ const bannerMessageOptions = {
   },
 };
 
+const queueOptions = {
+  Running: [
+    {
+      request: { pullRequestId: 10 },
+      state: 'running',
+    },
+    {
+      request: { pullRequestId: 11 },
+      state: 'running',
+    },
+    {
+      request: { pullRequestId: 12 },
+      state: 'queued',
+    },
+    {
+      request: { pullRequestId: 13 },
+      state: 'queued',
+    },
+  ],
+  Waiting: [
+    {
+      request: { pullRequestId: 10 },
+      state: 'queued',
+    },
+    {
+      request: { pullRequestId: 11 },
+      state: 'queued',
+    },
+    {
+      request: { pullRequestId: 8 },
+      state: 'running',
+    },
+    {
+      request: { pullRequestId: 9 },
+      state: 'running',
+    },
+  ],
+};
+
 export default {
   title: 'Message',
   component: Message,
   argTypes: {
+    queue: {
+      defaultValue: 'Running',
+      options: Object.keys(queueOptions),
+      mapping: queueOptions,
+    },
     onCheckAgainClicked: {
       action: 'onCheckAgainClicked',
     },
@@ -40,10 +84,6 @@ export default {
       options: Object.keys(bannerMessageOptions),
       mapping: bannerMessageOptions,
     },
-    loading: {
-      control: { type: 'select' },
-      options: [undefined, 'land', 'land-when-able'],
-    },
   },
 } as ComponentMeta<typeof Message>;
 
@@ -54,7 +94,8 @@ Configurable.args = {
   appName: 'Landkid',
   status: 'can-land',
   canLandWhenAble: true,
-  loading: null,
+  loadStatus: 'loaded',
+  pullRequestId: 10,
   errors: [
     'All tasks must be resolved',
     'Must be approved',

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -9,6 +9,7 @@ import Confetti from 'react-dom-confetti';
 
 import Errors from './Errors';
 import Warnings from './Warnings';
+import Queue from './Queue';
 import loadingRectangleStyles from './styles/loadingRectangleStyles';
 
 type Status =
@@ -95,6 +96,9 @@ const Message = ({
             <div className={loadingRectangleStyles} style={{ width: '60%' }} />
           </>
         );
+      }
+      case 'queued': {
+        return <Queue />;
       }
       case 'cannot-land': {
         return <>This pull request cannot land until the criteria below has been met.</>;

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -11,48 +11,66 @@ import Errors from './Errors';
 import Warnings from './Warnings';
 import Queue from './Queue';
 import loadingRectangleStyles from './styles/loadingRectangleStyles';
+import { LoadStatus, QueueResponse, Status } from './types';
+import { css, keyframes } from 'emotion';
 
-type Status =
-  | 'checking-can-land'
-  | 'cannot-land'
-  | 'queued'
-  | 'can-land'
-  | 'pr-closed'
-  | 'user-denied-access'
-  | 'unknown-error';
+const getMessageAppearance = (
+  loadStatus: LoadStatus,
+  status: Status | undefined,
+): SectionMessageProps['appearance'] => {
+  if (loadStatus === 'loading' || !status) {
+    return 'information';
+  }
 
-type Loading = 'land' | 'land-when-able';
+  const messageAppearance: { [keyof in Status]: SectionMessageProps['appearance'] } = {
+    running: 'information',
+    'awaiting-merge': 'information',
+    'will-queue-when-ready': 'information',
+    merging: 'information',
+    'cannot-land': 'warning',
+    queued: 'success',
+    'can-land': 'success',
+    'pr-closed': 'success',
+    'user-denied-access': 'error',
+    'unknown-error': 'error',
+  };
 
-const messageAppearance: { [keyof in Status]: SectionMessageProps['appearance'] } = {
-  'checking-can-land': 'information',
-  'cannot-land': 'warning',
-  queued: 'success',
-  'can-land': 'success',
-  'pr-closed': 'success',
-  'user-denied-access': 'error',
-  'unknown-error': 'error',
-} as const;
+  return messageAppearance[status];
+};
 
-const messageTitle: { [keyof in Status]: string } = {
-  'checking-can-land': 'Checking land status...',
-  'cannot-land': 'Not ready to land',
-  queued: 'Queued to land!',
-  'can-land': 'Ready to land!',
-  'pr-closed': 'Pull request is already closed',
-  'user-denied-access': 'Access denied',
-  'unknown-error': 'An unknown error occurred',
-} as const;
+const getMessageTitle = (loadStatus: LoadStatus, status: Status | undefined): string => {
+  if (loadStatus === 'loading' || !status) {
+    return 'Checking land status...';
+  }
+
+  const messageTitle: { [keyof in Status]: string } = {
+    running: 'Building...',
+    'awaiting-merge': 'Awaiting to merge pull request...',
+    'will-queue-when-ready': 'Queued to land when ready!',
+    merging: 'Pull request is being merged...',
+    'cannot-land': 'Not ready to land',
+    queued: 'Queued to land!',
+    'can-land': 'Ready to land!',
+    'pr-closed': 'Pull request is already closed',
+    'user-denied-access': 'Access denied',
+    'unknown-error': 'An unknown error occurred',
+  };
+  return messageTitle[status];
+};
 
 type MessageProps = {
   appName: string;
-  status: Status;
+  status?: Status;
   onLandClicked: () => void;
   onLandWhenAbleClicked: () => void;
   onCheckAgainClicked: () => void;
   canLandWhenAble: boolean;
   errors: string[];
   warnings: string[];
-  loading?: Loading;
+  loadStatus: LoadStatus;
+  queue?: QueueResponse['queue'];
+  pullRequestId: number;
+  repoName: string;
   bannerMessage: {
     messageExists: boolean;
     message: string;
@@ -74,10 +92,56 @@ const ExternalLink = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
+const messageContentStyles = css({
+  position: 'relative',
+});
+
+const refreshIndicatorStyles = css({
+  position: 'absolute',
+  right: 0,
+  top: '-35px',
+});
+
+const rotating = keyframes({
+  from: {
+    transform: 'rotate(0deg)',
+  },
+  to: {
+    transform: 'rotate(360deg)',
+  },
+});
+
+const pipelineSpinnerStyles = css({
+  animation: `${rotating} 2s ease-in-out infinite`,
+  transformOrigin: 'center',
+});
+
+const PipelineSpinner = () => {
+  return (
+    <svg
+      className={pipelineSpinnerStyles}
+      role="presentation"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M0 12a12.06 12.06 0 0 1 3.52-8.48A12.07 12.07 0 0 1 16.66.96c1.43.6 2.72 1.46 3.82 2.56a12.07 12.07 0 0 1 2.56 13.14 12.06 12.06 0 0 1-2.56 3.82 12.07 12.07 0 0 1-13.14 2.56 12.06 12.06 0 0 1-3.82-2.56A12.07 12.07 0 0 1 0 12Zm18.59 2.1a7.02 7.02 0 0 0-8.83-8.83l.91 2.86a4.01 4.01 0 0 1 5.06 5.05l2.86.92Zm-5.56 1.77a4.01 4.01 0 0 1-5.05-5.05l-2.86-.91a7.02 7.02 0 0 0 8.83 8.82l-.92-2.86Z"
+        fill="#0065FF"
+      />
+    </svg>
+  );
+};
+
 const Message = ({
-  loading,
+  loadStatus,
   appName,
   status,
+  queue,
   onLandClicked,
   onLandWhenAbleClicked,
   onCheckAgainClicked,
@@ -85,23 +149,52 @@ const Message = ({
   errors,
   warnings,
   bannerMessage,
+  pullRequestId,
+  repoName,
 }: MessageProps) => {
   const renderLandState = () => {
     switch (status) {
-      case 'checking-can-land': {
+      case 'running': {
+        const queueItem = queue?.find((item) => item.request.pullRequestId === pullRequestId);
+        const buildLink = queueItem ? (
+          <span>
+            (
+            <b>
+              <a
+                target="_blank"
+                href={`https://bitbucket.org/${repoName}/pipelines/results/${queueItem.request.buildId}`}
+              >
+                #{queueItem.request.buildId}
+              </a>
+            </b>
+            )
+          </span>
+        ) : (
+          ''
+        );
         return (
           <>
-            <div className={loadingRectangleStyles} />
-            <div className={loadingRectangleStyles} />
-            <div className={loadingRectangleStyles} style={{ width: '60%' }} />
+            Build checks are being run for this pull request {buildLink}. If they succeed, the pull
+            request will be merged.{' '}
           </>
         );
       }
+      case 'awaiting-merge':
+        return <>This pull request is waiting to be merged. </>;
+      case 'will-queue-when-ready':
+        return (
+          <>
+            This pull request will be added to the land queue when the criteria below have been met
+            —
+          </>
+        );
+      case 'merging':
+        return <>This pull request has passed all checks and is being merged.</>;
       case 'queued': {
-        return <Queue />;
+        return <Queue queue={queue} pullRequestId={pullRequestId} />;
       }
       case 'cannot-land': {
-        return <>This pull request cannot land until the criteria below has been met.</>;
+        return <>This pull request cannot land until the criteria below has been met —</>;
       }
       case 'user-denied-access': {
         return (
@@ -120,16 +213,26 @@ const Message = ({
       case 'pr-closed': {
         return null;
       }
+      default: {
+        return null;
+      }
     }
   };
 
-  const showWarnings = status === 'can-land' || status === 'cannot-land' || status === 'queued';
-  const showErrors = status === 'cannot-land' || status === 'queued';
+  const showWarnings =
+    status === 'can-land' ||
+    status === 'cannot-land' ||
+    status === 'queued' ||
+    status == 'will-queue-when-ready' ||
+    status === 'running';
+
+  const showErrors =
+    status === 'cannot-land' || status === 'queued' || status == 'will-queue-when-ready';
 
   const landButton = (
     <div style={{ marginRight: 15 }}>
       <Confetti
-        active={loading === 'land'}
+        active={loadStatus === 'queuing'}
         config={{
           angle: 20,
           spread: 58,
@@ -145,11 +248,52 @@ const Message = ({
           perspective: '500px',
         }}
       />
-      <Button appearance="primary" onClick={onLandClicked} isLoading={loading === 'land'}>
+      <Button appearance="primary" onClick={onLandClicked} isLoading={loadStatus === 'queuing'}>
         Land changes
       </Button>
     </div>
   );
+
+  const getActions = () => {
+    const actions = [];
+    switch (status) {
+      case 'can-land':
+        actions.push(landButton);
+        break;
+      case 'running':
+      case 'queued':
+        actions.push(
+          <SectionMessageAction linkComponent={ExternalLink} href="/current-state">
+            View queue
+          </SectionMessageAction>,
+        );
+        break;
+      case 'will-queue-when-ready':
+      case 'cannot-land': {
+        actions.push(
+          <SectionMessageAction onClick={onCheckAgainClicked}>Check again</SectionMessageAction>,
+        );
+        if (canLandWhenAble) {
+          actions.push(
+            <SectionMessageAction linkComponent={ExternalLink} onClick={onLandWhenAbleClicked}>
+              Land when ready {loadStatus === 'queuing' && <Spinner size="small" />}
+            </SectionMessageAction>,
+          );
+        }
+        break;
+      }
+    }
+
+    actions.push(
+      <SectionMessageAction href="/" linkComponent={ExternalLink}>
+        Learn about Landkid
+      </SectionMessageAction>,
+    );
+
+    return actions;
+  };
+
+  console.log('in message', { loadStatus });
 
   return (
     <div>
@@ -165,39 +309,29 @@ const Message = ({
         </div>
       )}
       <SectionMessage
-        title={messageTitle[status]}
-        appearance={messageAppearance[status]}
-        actions={[
-          ...(status === 'can-land' ? [landButton] : []),
-          ...(status === 'queued'
-            ? [
-                <SectionMessageAction linkComponent={ExternalLink} href="/current-state">
-                  View queue
-                </SectionMessageAction>,
-              ]
-            : []),
-          ...(status === 'cannot-land'
-            ? [
-                <SectionMessageAction onClick={onCheckAgainClicked}>
-                  Check again
-                </SectionMessageAction>,
-              ]
-            : []),
-          ...(canLandWhenAble && status === 'cannot-land'
-            ? [
-                <SectionMessageAction linkComponent={ExternalLink} onClick={onLandWhenAbleClicked}>
-                  Land when ready {loading === 'land-when-able' && <Spinner size="small" />}
-                </SectionMessageAction>,
-              ]
-            : []),
-          <SectionMessageAction href="/" linkComponent={ExternalLink}>
-            Learn about Landkid
-          </SectionMessageAction>,
-        ]}
+        icon={status === 'running' ? PipelineSpinner : undefined}
+        title={getMessageTitle(loadStatus, status)}
+        appearance={getMessageAppearance(loadStatus, status)}
+        actions={getActions()}
       >
-        {renderLandState()}
-        {showErrors && <Errors errors={errors} />}
-        {showWarnings && <Warnings warnings={warnings} />}
+        {loadStatus === 'loading' ? (
+          <>
+            <div className={loadingRectangleStyles} />
+            <div className={loadingRectangleStyles} />
+            <div className={loadingRectangleStyles} style={{ width: '60%' }} />
+          </>
+        ) : (
+          <div className={messageContentStyles}>
+            {renderLandState()}
+            {showErrors && <Errors errors={errors} />}
+            {showWarnings && <Warnings warnings={warnings} />}
+            {loadStatus === 'refreshing' && (
+              <div className={refreshIndicatorStyles}>
+                <Spinner size="small" />
+              </div>
+            )}
+          </div>
+        )}
       </SectionMessage>
     </div>
   );

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -45,7 +45,7 @@ const getMessageTitle = (loadStatus: LoadStatus, status: Status | undefined): st
 
   const messageTitle: { [keyof in Status]: string } = {
     running: 'Building...',
-    'awaiting-merge': 'Awaiting to merge pull request...',
+    'awaiting-merge': 'Waiting to merge pull request...',
     'will-queue-when-ready': 'Queued to land when ready!',
     merging: 'Pull request is being merged...',
     'cannot-land': 'Not ready to land',
@@ -180,7 +180,9 @@ const Message = ({
         );
       }
       case 'awaiting-merge':
-        return <>This pull request is waiting to be merged. </>;
+        return (
+          <>This pull request is waiting for other dependents to finish before it is merged. </>
+        );
       case 'will-queue-when-ready':
         return (
           <>

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -262,6 +262,7 @@ const Message = ({
         break;
       case 'running':
       case 'queued':
+      case 'awaiting-merge':
         actions.push(
           <SectionMessageAction linkComponent={ExternalLink} href="/current-state">
             View queue
@@ -269,6 +270,10 @@ const Message = ({
         );
         break;
       case 'will-queue-when-ready':
+        actions.push(
+          <SectionMessageAction onClick={onCheckAgainClicked}>Check again</SectionMessageAction>,
+        );
+        break;
       case 'cannot-land': {
         actions.push(
           <SectionMessageAction onClick={onCheckAgainClicked}>Check again</SectionMessageAction>,
@@ -292,8 +297,6 @@ const Message = ({
 
     return actions;
   };
-
-  console.log('in message', { loadStatus });
 
   return (
     <div>

--- a/src/static/bitbucket/components/Queue.stories.tsx
+++ b/src/static/bitbucket/components/Queue.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { QueueBase } from './Queue';
+
+export default {
+  title: 'Queue',
+  component: QueueBase,
+  argTypes: {
+    loadingState: {
+      control: { type: 'select' },
+      options: ['not-loaded', 'loading', 'refreshing', 'error', 'loaded'],
+    },
+  },
+} as ComponentMeta<typeof QueueBase>;
+
+const Template: ComponentStory<typeof QueueBase> = (args) => <QueueBase {...args} />;
+
+export const Configurable = Template.bind({});
+
+Configurable.args = {
+  pullRequestId: 1,
+  currentState: {
+    queue: [{ request: { pullRequestId: 1 } }, { request: { pullRequestId: 2 } }],
+    waitingToQueue: [
+      { request: { pullRequestId: 3 } },
+      { request: { pullRequestId: 4 } },
+      { request: { pullRequestId: 5 } },
+    ],
+  },
+};

--- a/src/static/bitbucket/components/Queue.tsx
+++ b/src/static/bitbucket/components/Queue.tsx
@@ -59,7 +59,6 @@ const queueSeparatorStyle = css({
 const queueLabelStyle = css({
   marginTop: 6,
   marginBottom: 6,
-  fontWeight: 'bold',
 });
 
 type LoadingState = 'not-loaded' | 'loading' | 'refreshing' | 'error' | 'loaded';

--- a/src/static/bitbucket/components/Queue.tsx
+++ b/src/static/bitbucket/components/Queue.tsx
@@ -119,8 +119,6 @@ export const QueueBase = ({
     (pr) => pr.request.pullRequestId === currentPullRequestId,
   );
 
-  console.log({ loadingState, currentState, currentPullRequestId });
-  console.log({ prPositionWaitQueue, prPositionRunningQueue });
   const isPRInWaitQueue = prPositionWaitQueue > -1;
   const isPRInRunningQueue = prPositionRunningQueue > -1;
   const isPRInQueue = isPRInWaitQueue || isPRInRunningQueue;

--- a/src/static/bitbucket/components/Queue.tsx
+++ b/src/static/bitbucket/components/Queue.tsx
@@ -1,0 +1,202 @@
+import { css, keyframes } from 'emotion';
+import { G300, N60, N300, N400 } from '@atlaskit/theme/colors';
+import { proxyRequest } from '../utils/RequestProxy';
+import { RunnerState } from '../../../types';
+import { useEffect, useState } from 'react';
+
+const queueContainerStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+});
+
+const queueElementStyle = {
+  width: 20,
+  height: 20,
+  background: 'rgb(94 108 132 / 22%)',
+  borderRadius: '50%',
+  marginRight: 6,
+  fontSize: 10,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
+const queueElementInactiveStyle = css({
+  ...queueElementStyle,
+  background: 'rgb(94 108 132 / 22%)',
+  color: N60,
+});
+
+const queueElementActiveStyle = css({
+  ...queueElementStyle,
+  background: G300,
+  color: 'white',
+  boxShadow: `0px 0px 0px 2px white, 0px 0px 0px 3px ${G300}`,
+});
+
+const shimmer = keyframes({
+  from: {
+    background: N300,
+  },
+  to: {
+    background: N400,
+  },
+});
+
+const queueElementRunningStyle = css({
+  ...queueElementStyle,
+  animation: `${shimmer} 0.5s alternate infinite`,
+});
+
+const queueSeparatorStyle = css({
+  width: 2,
+  height: 20,
+  background: N60,
+  marginRight: 14,
+  marginLeft: 8,
+});
+
+const queueLabelStyle = css({
+  marginTop: 6,
+  marginBottom: 6,
+  fontWeight: 'bold',
+});
+
+type LoadingState = 'not-loaded' | 'loading' | 'refreshing' | 'error' | 'loaded';
+
+const useQueueResults = () => {
+  const [loadingState, setLoadingState] = useState<LoadingState>('not-loaded');
+  const [currentState, setCurrentState] = useState<Pick<RunnerState, 'queue' | 'waitingToQueue'>>({
+    queue: [],
+    waitingToQueue: [],
+  });
+
+  const fetchCurrentState = () => {
+    setLoadingState(loadingState === 'not-loaded' ? 'loading' : 'refreshing');
+    proxyRequest<RunnerState>('/current-state', 'GET')
+      .then(({ queue, waitingToQueue }) => {
+        setLoadingState('loaded');
+        setCurrentState({ queue, waitingToQueue });
+      })
+      .catch((err) => {
+        console.error('Failed to fetch PR status', err);
+        setLoadingState('error');
+      });
+  };
+
+  let intervalId: any;
+  useEffect(() => {
+    fetchCurrentState();
+    intervalId = setInterval(() => {
+      if (!document.hidden) {
+        fetchCurrentState();
+      }
+    }, 10000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return {
+    loadingState,
+    currentState,
+  };
+};
+
+export const QueueBase = ({
+  loadingState,
+  currentState,
+  currentPullRequestId,
+}: {
+  loadingState: LoadingState;
+  currentState: Pick<RunnerState, 'queue' | 'waitingToQueue'>;
+  currentPullRequestId: number;
+}) => {
+  const prPositionWaitQueue = currentState.waitingToQueue.findIndex(
+    (pr) => pr.request.pullRequestId === currentPullRequestId,
+  );
+  const prPositionRunningQueue = currentState.queue.findIndex(
+    (pr) => pr.request.pullRequestId === currentPullRequestId,
+  );
+
+  console.log({ loadingState, currentState, currentPullRequestId });
+  console.log({ prPositionWaitQueue, prPositionRunningQueue });
+  const isPRInWaitQueue = prPositionWaitQueue > -1;
+  const isPRInRunningQueue = prPositionRunningQueue > -1;
+  const isPRInQueue = isPRInWaitQueue || isPRInRunningQueue;
+
+  const totalWaiting = currentState.waitingToQueue.length;
+  const totalRunning = currentState.queue.length;
+
+  if (loadingState === 'error') {
+    return <div>Failed to fetch queue.</div>;
+  }
+
+  if (loadingState === 'loading' || loadingState === 'not-loaded') {
+    return <div>Loading...</div>;
+  }
+
+  if (!isPRInQueue) {
+    return <div> Pull request is no longer in queue. </div>;
+  }
+
+  return (
+    <>
+      <div className={queueContainerStyle}>
+        {[...new Array(totalRunning).keys()].map((_, index) => (
+          <div
+            key={index}
+            className={
+              isPRInRunningQueue && index === prPositionRunningQueue
+                ? queueElementActiveStyle
+                : queueElementRunningStyle
+            }
+          ></div>
+        ))}
+        <div className={queueSeparatorStyle}></div>
+        {[...new Array(totalWaiting).keys()].map((_, index) => (
+          <div
+            key={index}
+            className={
+              isPRInWaitQueue && index === prPositionWaitQueue
+                ? queueElementActiveStyle
+                : queueElementInactiveStyle
+            }
+          >
+            {index + 1}
+          </div>
+        ))}
+      </div>
+      {isPRInWaitQueue ? (
+        prPositionWaitQueue === 0 ? (
+          <div className={queueLabelStyle}>Land request is waiting at start of the queue</div>
+        ) : (
+          <div className={queueLabelStyle}>
+            {' '}
+            Land request is behind {prPositionWaitQueue} other land requests...
+          </div>
+        )
+      ) : null}
+      {isPRInRunningQueue && (
+        <div className={queueLabelStyle}>Land request is currently being built...</div>
+      )}
+    </>
+  );
+};
+
+const Queue = () => {
+  const { loadingState, currentState } = useQueueResults();
+  const qs = new URLSearchParams(window.location.search);
+  const pullRequestId = parseInt(qs.get('pullRequestId') || '');
+
+  return (
+    <QueueBase
+      currentState={currentState}
+      loadingState={loadingState}
+      currentPullRequestId={pullRequestId}
+    />
+  );
+};
+
+export default Queue;

--- a/src/static/bitbucket/components/types.ts
+++ b/src/static/bitbucket/components/types.ts
@@ -1,0 +1,16 @@
+import { RunnerState } from '../../../types';
+
+export type Status =
+  | 'cannot-land'
+  | 'queued'
+  | 'running'
+  | 'will-queue-when-ready'
+  | 'can-land'
+  | 'awaiting-merge'
+  | 'merging'
+  | 'pr-closed'
+  | 'user-denied-access'
+  | 'unknown-error';
+
+export type LoadStatus = 'loaded' | 'not-loaded' | 'loading' | 'refreshing' | 'queuing';
+export type QueueResponse = Pick<RunnerState, 'queue'>;

--- a/src/static/bitbucket/index.html
+++ b/src/static/bitbucket/index.html
@@ -1,21 +1,28 @@
 <html>
+<head>
+  <script>
+    if (window.parent !== window) {
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    }
+  </script>
   <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
           Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       }
   </style>
-  <body>
-    <div id="app" class="ac-content" style="min-height: 90px">
-      <div style="width:100%; display: flex; align-items: center; justify-content: center; font-weight: bold">
-        Loading Landkid....
-      </div>
-    </div>
+</head>
+<body>
+<div id="app" class="ac-content" style="min-height: 90px">
+  <div style="width:100%; display: flex; align-items: center; justify-content: center; font-weight: bold">
+    Loading Landkid....
+  </div>
+</div>
 
-    <script
-      data-requirecontext="_"
-      data-requiremodule="connect-bitbucket"
-      src="https://bitbucket.org/atlassian-connect/all.js"
-    ></script>
-  </body>
+<script
+  data-requirecontext="_"
+  data-requiremodule="connect-bitbucket"
+  src="https://bitbucket.org/atlassian-connect/all.js"
+></script>
+</body>
 </html>

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -1,12 +1,10 @@
 interface BBRequest<T> {
-  (
-    opts: {
-      url: string;
-      type?: string;
-      success: (resp: T) => void;
-      error: (err: any) => void;
-    },
-  ): void;
+  (opts: {
+    url: string;
+    type?: string;
+    success: (resp: T) => void;
+    error: (err: any) => void;
+  }): void;
 }
 
 const AP = (window as any).AP as {
@@ -19,12 +17,25 @@ export function proxyRequest<T>(url: string, type: string): Promise<T> {
     const repoId = qs.get('repoId');
     const pullRequestId = qs.get('pullRequestId');
 
-    AP.require('proxyRequest', req => {
+    AP.require('proxyRequest', (req) => {
       req({
         url: `${url}/${repoId}/${pullRequestId}`,
         type,
-        success: resp => resolve(resp as any),
-        error: err => reject(err),
+        success: (resp) => resolve(resp as any),
+        error: (err) => reject(err),
+      });
+    });
+  });
+}
+
+export function proxyRequestBare<T>(url: string, type: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    AP.require('proxyRequest', (req) => {
+      req({
+        url: url,
+        type,
+        success: (resp) => resolve(resp as any),
+        error: (err) => reject(err),
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,16 +122,6 @@
     "@babel/runtime" "^7.0.0"
     bind-event-listener "^2.1.1"
 
-"@atlaskit/focus-ring@^1.0.0":
-  version "1.0.6"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-1.0.6.tgz#be7df85c1a53ecd984b421b77ed266b7dc402f63"
-  integrity sha512-aqTrhYnJDWjrwJrq4vakip9vreZmQKMP/2mP9glQoXIQMCsmOK6hn8G865q+7wfq1TjlbSZwBS7kxX+op+ymWw==
-  dependencies:
-    "@atlaskit/theme" "^12.1.0"
-    "@atlaskit/tokens" "^0.10.0"
-    "@babel/runtime" "^7.0.0"
-    "@emotion/core" "^10.0.9"
-
 "@atlaskit/icon@^15.0.1":
   version "15.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-15.0.3.tgz#6071ac0a33d2445d6985972a66957c05d871423d"
@@ -147,18 +137,6 @@
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-21.10.7.tgz#6395b8a795173f5014cf85365d2b82a7e978af31"
   integrity sha512-S1e/V1p11ULNpo3XfDXN1tP6HyxnTyHUQxU1UlEAtFQ933dGIRRur46fZiVKOpMZ9cKjlPIBjf7EBkfaQRtNQw==
   dependencies:
-    "@atlaskit/theme" "^12.1.0"
-    "@atlaskit/tokens" "^0.10.0"
-    "@babel/runtime" "^7.0.0"
-    "@emotion/core" "^10.0.9"
-
-"@atlaskit/menu@^1.3.9":
-  version "1.3.9"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/menu/-/menu-1.3.9.tgz#85d4459b693b6d8723ffa676afa399533c7e2ce4"
-  integrity sha512-XWuAMUyRqgoUNLkkpyif/d4qOCQzzbusT7KRC96YvpqS5Vbogbi8m93ZyXccSkjat8ByVlY8p1sgHWSzGko1Dw==
-  dependencies:
-    "@atlaskit/ds-lib" "^2.1.0"
-    "@atlaskit/focus-ring" "^1.0.0"
     "@atlaskit/theme" "^12.1.0"
     "@atlaskit/tokens" "^0.10.0"
     "@babel/runtime" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12234,6 +12234,11 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intersection-observer@^9.4.0:
+  version "9.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz#f6b6e616e625f9bf255857c5cba9dbf7b1825ec7"
+  integrity sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==
+
 react-is@17.0.2, react-is@^17.0.1:
   version "17.0.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -12268,6 +12273,11 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-usestateref@^1.0.8:
+  version "1.0.8"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/react-usestateref/-/react-usestateref-1.0.8.tgz#b40519af0d6f3b3822c70eb5db80f7d47f1b1ff5"
+  integrity sha512-whaE6H0XGarFKwZ3EYbpHBsRRCLZqdochzg/C7e+b6VFMTA3LS3K4ZfpI4NT40iy83jG89rGXrw70P9iDfOdsA==
 
 react@^16.4.0, react@^16.8.0:
   version "16.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,16 @@
     "@babel/runtime" "^7.0.0"
     bind-event-listener "^2.1.1"
 
+"@atlaskit/focus-ring@^1.0.0":
+  version "1.0.6"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-1.0.6.tgz#be7df85c1a53ecd984b421b77ed266b7dc402f63"
+  integrity sha512-aqTrhYnJDWjrwJrq4vakip9vreZmQKMP/2mP9glQoXIQMCsmOK6hn8G865q+7wfq1TjlbSZwBS7kxX+op+ymWw==
+  dependencies:
+    "@atlaskit/theme" "^12.1.0"
+    "@atlaskit/tokens" "^0.10.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/core" "^10.0.9"
+
 "@atlaskit/icon@^15.0.1":
   version "15.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-15.0.3.tgz#6071ac0a33d2445d6985972a66957c05d871423d"
@@ -137,6 +147,18 @@
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-21.10.7.tgz#6395b8a795173f5014cf85365d2b82a7e978af31"
   integrity sha512-S1e/V1p11ULNpo3XfDXN1tP6HyxnTyHUQxU1UlEAtFQ933dGIRRur46fZiVKOpMZ9cKjlPIBjf7EBkfaQRtNQw==
   dependencies:
+    "@atlaskit/theme" "^12.1.0"
+    "@atlaskit/tokens" "^0.10.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/core" "^10.0.9"
+
+"@atlaskit/menu@^1.3.9":
+  version "1.3.9"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/menu/-/menu-1.3.9.tgz#85d4459b693b6d8723ffa676afa399533c7e2ce4"
+  integrity sha512-XWuAMUyRqgoUNLkkpyif/d4qOCQzzbusT7KRC96YvpqS5Vbogbi8m93ZyXccSkjat8ByVlY8p1sgHWSzGko1Dw==
+  dependencies:
+    "@atlaskit/ds-lib" "^2.1.0"
+    "@atlaskit/focus-ring" "^1.0.0"
     "@atlaskit/theme" "^12.1.0"
     "@atlaskit/tokens" "^0.10.0"
     "@babel/runtime" "^7.0.0"


### PR DESCRIPTION
https://user-images.githubusercontent.com/8946207/189759073-5cf64efe-058f-4c52-8239-70773093ef4d.mp4

Render all reasons to browse to the queue page un-necessary with auto-updating queue statuses without ever needing to refresh the page.