### PR TITLE
Add squash merge feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@atlaskit/button": "^15.0.0",
+    "@atlaskit/checkbox": "^12.3.19",
     "@atlaskit/css-reset": "^6.3.13",
     "@atlaskit/pagination": "^8.0.5",
     "@atlaskit/section-message": "^6.1.12",
@@ -106,8 +107,8 @@
     "express-session": "^1.17.1",
     "express-winston": "^3.0.1",
     "micromatch": "^4.0.2",
-    "p-limit": "^3.1.0",
     "mime": "^3.0.0",
+    "p-limit": "^3.1.0",
     "passport": "^0.4.1",
     "passport-oauth2": "^1.5.0",
     "pg": "^8.2.1",

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -91,6 +91,7 @@ export class BitbucketAPI {
     const { status, statusText, headers, data } = await this.bitbucketMerger.attemptMerge(
       pullRequestId,
       message,
+      options.mergeStrategy
     );
 
     if (status === 200) {

--- a/src/bitbucket/BitbucketMerger.ts
+++ b/src/bitbucket/BitbucketMerger.ts
@@ -11,12 +11,22 @@ export class BitbucketMerger {
 
   constructor(private baseUrl: string) {}
 
-  attemptMerge = async (prId: number, message: string, mergeStrategy?: IMergeStrategy) => {
+  attemptMerge = async (
+    prId: number,
+    message: string,
+    mergeStrategy: IMergeStrategy = 'merge-commit',
+  ) => {
     const endpoint = `${this.baseUrl}/pullrequests/${prId}/merge`;
+
+    const mergeStrategyMapper: { [key in IMergeStrategy]: string } = {
+      'merge-commit': 'merge_commit',
+      squash: 'squash',
+    };
+
     const body = {
       close_source_branch: true,
       message,
-      merge_strategy: mergeStrategy?.split('-').join('_') || 'merge_commit',
+      merge_strategy: mergeStrategyMapper[mergeStrategy],
     };
 
     return axios.post(

--- a/src/bitbucket/BitbucketMerger.ts
+++ b/src/bitbucket/BitbucketMerger.ts
@@ -11,12 +11,12 @@ export class BitbucketMerger {
 
   constructor(private baseUrl: string) {}
 
-  attemptMerge = async (prId: number, message: string) => {
+  attemptMerge = async (prId: number, message: string, mergeStrategy?: IMergeStrategy) => {
     const endpoint = `${this.baseUrl}/pullrequests/${prId}/merge`;
     const body = {
       close_source_branch: true,
       message,
-      merge_strategy: 'merge_commit',
+      merge_strategy: mergeStrategy?.split('-').join('_') || 'merge_commit',
     };
 
     return axios.post(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -79,6 +79,17 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   @Column(Sequelize.INTEGER)
   priority: number;
 
+  @AllowNull(true)
+  @Column(
+    Sequelize.ENUM({
+      values: [
+        'squash',
+        'merge-commit',
+      ],
+    }),
+  )
+  mergeStrategy: IMergeStrategy;
+
   /* Reload the instance after creation so that we eagerly load associations
    * see https://github.com/sequelize/sequelize/issues/3807#issuecomment-438237173
    */

--- a/src/db/migrations/08__mergeStrategyColumn.ts
+++ b/src/db/migrations/08__mergeStrategyColumn.ts
@@ -1,0 +1,19 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  up: function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.describeTable('LandRequest').then((table: any) => {
+      if (table.mergeStrategy) return;
+      return query.addColumn('LandRequest', 'mergeStrategy', {
+        type: Sequelize.ENUM({
+          values: ['squash', 'merge-commit'],
+        }),
+        allowNull: true,
+      });
+    });
+  },
+  // VIOLATES FOREIGN KEY CONSTRAINT
+  down: function () {
+    throw new Error('NO DROP FUNCTION FOR THIS MIGRATION');
+  },
+};

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -243,7 +243,7 @@ export class Runner {
       this.config.mergeSettings &&
       this.config.mergeSettings.skipBuildOnDependentsAwaitingMerge;
 
-    this.client.mergePullRequest(landRequestStatus, { skipCI }).then(async (result) => {
+    this.client.mergePullRequest(landRequestStatus, { skipCI, mergeStrategy: landRequest.mergeStrategy }).then(async (result) => {
       if (result === BitbucketAPI.SUCCESS) {
         const end = Date.now();
         const queuedDate = await this.getLandRequestQueuedDate(landRequest.id);
@@ -498,6 +498,7 @@ export class Runner {
         triggererAccountId: landRequestOptions.triggererAccountId,
         pullRequestId: pr.prId,
         forCommit: landRequestOptions.commit,
+        mergeStrategy: landRequestOptions.mergeStrategy
       },
       {
         include: [PullRequest],

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -8,6 +8,10 @@ import { Runner } from '../../../lib/Runner';
 import { Logger } from '../../../lib/Logger';
 import { eventEmitter } from '../../../lib/Events';
 
+interface LandBody {
+  mergeStrategy?: IMergeStrategy;
+}
+
 export function proxyRoutes(runner: Runner, client: BitbucketClient) {
   const router = express();
 
@@ -80,6 +84,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
     '/land',
     wrap(async (req, res) => {
       const { aaid, pullRequestId, commit, accountId } = req.query as Record<string, string>;
+      const { mergeStrategy } = req.body as LandBody;
       const prId = parseInt(pullRequestId, 10);
       Logger.verbose('Request to land', {
         namespace: 'routes:bitbucket:proxy:land',
@@ -110,6 +115,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
         prAuthorAccountId: prInfo.author,
         prSourceBranch: prInfo.sourceBranch,
         prTargetBranch: prInfo.targetBranch,
+        mergeStrategy,
       };
 
       await runner.enqueue(landRequest);
@@ -135,6 +141,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
     '/land-when-able',
     wrap(async (req, res) => {
       const { aaid, pullRequestId, commit, accountId } = req.query as Record<string, string>;
+      const { mergeStrategy } = req.body as LandBody;
       const prId = parseInt(pullRequestId, 10);
       Logger.verbose('Request to land when able', {
         namespace: 'routes:bitbucket:proxy:land-when-able',
@@ -160,6 +167,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
         prAuthorAccountId: prInfo.author,
         prSourceBranch: prInfo.sourceBranch,
         prTargetBranch: prInfo.targetBranch,
+        mergeStrategy,
       };
       await runner.addToWaitingToLand(landRequest);
       Logger.info('Pull request will land when able', {

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -54,10 +54,10 @@ const App = () => {
   const [queue, setQueue] = useState<QueueResponse['queue'] | undefined>();
   const [_, setLoadStatus, loadStatusRef] = useState<LoadStatus>('not-loaded');
   const [state, dispatch] = useState(initialState);
-  const [isChecked, setIsChecked] = useState(true);
+  const [isSquashMergeChecked, setIsSquashMergeChecked] = useState(true);
 
   const onChange = (): void => {
-    setIsChecked((prev: boolean) => !prev);
+    setIsSquashMergeChecked((prev: boolean) => !prev);
   };
 
   const { ref, inView } = useInView({
@@ -162,7 +162,9 @@ const App = () => {
 
   const onLandClicked = () => {
     setLoadStatus('queuing');
-    proxyRequest('/land', 'POST', { mergeStrategy: isChecked ? 'squash' : 'merge-commit' })
+    proxyRequest('/land', 'POST', {
+      mergeStrategy: isSquashMergeChecked ? 'squash' : 'merge-commit',
+    })
       .then(() => {
         setStatus('queued');
         checkQueueStatus();
@@ -179,7 +181,7 @@ const App = () => {
   const onLandWhenAbleClicked = () => {
     setLoadStatus('queuing');
     proxyRequest('/land-when-able', 'POST', {
-      mergeStrategy: isChecked ? 'squash' : 'merge-commit',
+      mergeStrategy: isSquashMergeChecked ? 'squash' : 'merge-commit',
     })
       .then(() => {
         setStatus('will-queue-when-ready');
@@ -218,7 +220,7 @@ const App = () => {
         onCheckAgainClicked={onCheckAgainClicked}
         onLandWhenAbleClicked={onLandWhenAbleClicked}
         onLandClicked={onLandClicked}
-        isChecked={isChecked}
+        isSquashMergeChecked={isSquashMergeChecked}
         onChange={onChange}
         pullRequestId={pullRequestId}
         repoName={repoName}

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -246,7 +246,7 @@ const App = () => {
         onLandWhenAbleClicked={onLandWhenAbleClicked}
         onLandClicked={onLandClicked}
         isSquashMergeChecked={isSquashMergeChecked}
-        onChange={onChange}
+        onMergeStrategyChange={onChange}
         pullRequestId={pullRequestId}
         repoName={repoName}
       />

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -46,6 +46,11 @@ const App = () => {
   const [status, setStatus] = useState<Status>('checking-can-land');
   const [loading, setLoading] = useState<Loading | undefined>();
   const [state, dispatch] = useState(initialState);
+  const [isChecked, setIsChecked] = useState(true);
+
+  const onChange = (): void => {
+    setIsChecked((prev: boolean) => !prev);
+  };
 
   useEffect(() => {
     const isOpen = qs.get('state') === 'OPEN';
@@ -81,7 +86,7 @@ const App = () => {
 
   const onLandClicked = () => {
     setLoading('land');
-    proxyRequest('/land', 'POST')
+    proxyRequest('/land', 'POST', { mergeStrategy: isChecked ? 'squash' : 'merge-commit' })
       .then(() => {
         setLoading(undefined);
         setStatus('queued');
@@ -95,7 +100,9 @@ const App = () => {
 
   const onLandWhenAbleClicked = () => {
     setLoading('land-when-able');
-    proxyRequest('/land-when-able', 'POST')
+    proxyRequest('/land-when-able', 'POST', {
+      mergeStrategy: isChecked ? 'squash' : 'merge-commit',
+    })
       .then(() => {
         setLoading(undefined);
         setStatus('queued');
@@ -129,6 +136,8 @@ const App = () => {
         onCheckAgainClicked={onCheckAgainClicked}
         onLandWhenAbleClicked={onLandWhenAbleClicked}
         onLandClicked={onLandClicked}
+        isChecked={isChecked}
+        onChange={onChange}
       />
     </div>
   );

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -78,7 +78,7 @@ type MessageProps = {
     message: string;
     messageType: 'default' | 'warning' | 'error';
   } | null;
-  isChecked: boolean;
+  isSquashMergeChecked: boolean;
   onChange: () => void;
 };
 
@@ -153,7 +153,7 @@ const Message = ({
   errors,
   warnings,
   bannerMessage,
-  isChecked,
+  isSquashMergeChecked,
   onChange,
   pullRequestId,
   repoName,
@@ -344,7 +344,7 @@ const Message = ({
             {(status === 'can-land' || (canLandWhenAble && status === 'cannot-land')) && (
               <div className={checkboxStyles}>
                 <Checkbox
-                  isChecked={isChecked}
+                  isChecked={isSquashMergeChecked}
                   onChange={onChange}
                   label={`Squash commits when merging`}
                 />

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -5,6 +5,7 @@ import SectionMessage, {
 } from '@atlaskit/section-message';
 import { LoadingButton as Button } from '@atlaskit/button';
 import Spinner from '@atlaskit/spinner';
+import { Checkbox } from '@atlaskit/checkbox';
 import Confetti from 'react-dom-confetti';
 
 import Errors from './Errors';
@@ -57,6 +58,8 @@ type MessageProps = {
     message: string;
     messageType: 'default' | 'warning' | 'error';
   } | null;
+  isChecked: boolean;
+  onChange: () => void;
 };
 
 /**
@@ -84,6 +87,8 @@ const Message = ({
   errors,
   warnings,
   bannerMessage,
+  isChecked,
+  onChange,
 }: MessageProps) => {
   const renderLandState = () => {
     switch (status) {
@@ -194,6 +199,7 @@ const Message = ({
         {renderLandState()}
         {showErrors && <Errors errors={errors} />}
         {showWarnings && <Warnings warnings={warnings} />}
+        <Checkbox isChecked={isChecked} onChange={onChange} label={`Squash commits when merging`} />
       </SectionMessage>
     </div>
   );

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -79,7 +79,7 @@ type MessageProps = {
     messageType: 'default' | 'warning' | 'error';
   } | null;
   isSquashMergeChecked: boolean;
-  onChange: () => void;
+  onMergeStrategyChange: () => void;
 };
 
 /**
@@ -154,7 +154,7 @@ const Message = ({
   warnings,
   bannerMessage,
   isSquashMergeChecked,
-  onChange,
+  onMergeStrategyChange: onChange,
   pullRequestId,
   repoName,
 }: MessageProps) => {

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -199,7 +199,7 @@ const Message = ({
         {renderLandState()}
         {showErrors && <Errors errors={errors} />}
         {showWarnings && <Warnings warnings={warnings} />}
-        {status === 'can-land' && (
+        {(status === 'can-land' || (canLandWhenAble && status === 'cannot-land')) && (
           <Checkbox
             isChecked={isChecked}
             onChange={onChange}

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -12,6 +12,7 @@ import Errors from './Errors';
 import Warnings from './Warnings';
 import Queue from './Queue';
 import loadingRectangleStyles from './styles/loadingRectangleStyles';
+import checkboxStyles from './styles/checkboxStyles';
 import { LoadStatus, QueueResponse, Status } from './types';
 import { css, keyframes } from 'emotion';
 
@@ -341,11 +342,13 @@ const Message = ({
               </div>
             )}
             {(status === 'can-land' || (canLandWhenAble && status === 'cannot-land')) && (
-              <Checkbox
-                isChecked={isChecked}
-                onChange={onChange}
-                label={`Squash commits when merging`}
-              />
+              <div className={checkboxStyles}>
+                <Checkbox
+                  isChecked={isChecked}
+                  onChange={onChange}
+                  label={`Squash commits when merging`}
+                />
+              </div>
             )}
           </div>
         )}

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -199,7 +199,13 @@ const Message = ({
         {renderLandState()}
         {showErrors && <Errors errors={errors} />}
         {showWarnings && <Warnings warnings={warnings} />}
-        <Checkbox isChecked={isChecked} onChange={onChange} label={`Squash commits when merging`} />
+        {status === 'can-land' && (
+          <Checkbox
+            isChecked={isChecked}
+            onChange={onChange}
+            label={`Squash commits when merging`}
+          />
+        )}
       </SectionMessage>
     </div>
   );

--- a/src/static/bitbucket/components/styles/checkboxStyles.ts
+++ b/src/static/bitbucket/components/styles/checkboxStyles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+const checkboxStyles = css({
+  marginTop: '10px',
+});
+
+export default checkboxStyles;

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -19,7 +19,7 @@ const AP = (window as any).AP as {
   require: (name: 'proxyRequest', fn: <T>(req: BBRequest<T>) => void) => void;
 };
 
-export function proxyRequest<T>(url: string, type: string, data?: Data): Promise<T> {
+export function proxyRequest<T>(url: string, type: string, data?: Data<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const qs = new URLSearchParams(window.location.search);
     const repoId = qs.get('repoId');

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -9,7 +9,7 @@ interface BBRequest<T> {
   }): void;
 }
 
-interface Data {
+interface Data<T> {
   mergeStrategy?: string;
   success?: (resp: T) => void;
   error?: (err: any) => void;

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -3,6 +3,7 @@ interface BBRequest<T> {
     url: string;
     type?: string;
     data?: string;
+    contentType?: string;
     success: (resp: T) => void;
     error: (err: any) => void;
   }): void;
@@ -21,12 +22,14 @@ export function proxyRequest<T>(url: string, type: string, data?: Data): Promise
     const qs = new URLSearchParams(window.location.search);
     const repoId = qs.get('repoId');
     const pullRequestId = qs.get('pullRequestId');
+    const contentType = data ? 'application/json' : undefined;
 
     AP.require('proxyRequest', (req) => {
       req({
         url: `${url}/${repoId}/${pullRequestId}`,
         type,
         data: JSON.stringify(data),
+        contentType,
         success: (resp) => resolve(resp as any),
         error: (err) => reject(err),
       });

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -9,22 +9,16 @@ interface BBRequest<T> {
   }): void;
 }
 
-interface Data<T> {
-  mergeStrategy?: string;
-  success?: (resp: T) => void;
-  error?: (err: any) => void;
-}
-
 const AP = (window as any).AP as {
   require: (name: 'proxyRequest', fn: <T>(req: BBRequest<T>) => void) => void;
 };
 
-export function proxyRequest<T>(url: string, type: string, data?: Data<T>): Promise<T> {
+export function proxyRequest<T>(url: string, type: string, data?: object): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const qs = new URLSearchParams(window.location.search);
     const repoId = qs.get('repoId');
     const pullRequestId = qs.get('pullRequestId');
-    const contentType = data ? 'application/json' : undefined;
+    const contentType = 'application/json';
 
     AP.require('proxyRequest', (req) => {
       req({

--- a/src/static/bitbucket/utils/RequestProxy.ts
+++ b/src/static/bitbucket/utils/RequestProxy.ts
@@ -1,30 +1,34 @@
 interface BBRequest<T> {
-  (
-    opts: {
-      url: string;
-      type?: string;
-      success: (resp: T) => void;
-      error: (err: any) => void;
-    },
-  ): void;
+  (opts: {
+    url: string;
+    type?: string;
+    data?: string;
+    success: (resp: T) => void;
+    error: (err: any) => void;
+  }): void;
+}
+
+interface Data {
+  mergeStrategy: string;
 }
 
 const AP = (window as any).AP as {
   require: (name: 'proxyRequest', fn: <T>(req: BBRequest<T>) => void) => void;
 };
 
-export function proxyRequest<T>(url: string, type: string): Promise<T> {
+export function proxyRequest<T>(url: string, type: string, data?: Data): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const qs = new URLSearchParams(window.location.search);
     const repoId = qs.get('repoId');
     const pullRequestId = qs.get('pullRequestId');
 
-    AP.require('proxyRequest', req => {
+    AP.require('proxyRequest', (req) => {
       req({
         url: `${url}/${repoId}/${pullRequestId}`,
         type,
-        success: resp => resolve(resp as any),
-        error: err => reject(err),
+        data: JSON.stringify(data),
+        success: (resp) => resolve(resp as any),
+        error: (err) => reject(err),
       });
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type LandRequestOptions = {
   triggererAaid: string;
   triggererAccountId: string;
   commit: string;
+  mergeStrategy?: IMergeStrategy;
 };
 
 export type RepoConfig = {
@@ -121,4 +122,5 @@ export type RunnerState = {
 
 export type MergeOptions = {
   skipCI?: boolean;
+  mergeStrategy?: IMergeStrategy;
 };

--- a/tests/unit/BitbucketAPI.test.ts
+++ b/tests/unit/BitbucketAPI.test.ts
@@ -10,7 +10,7 @@ jest.mock('delay');
 
 jest.mock('../../src/bitbucket/BitbucketAuthenticator', () => ({
   bitbucketAuthenticator: {
-    getAuthConfig: jest.fn(),
+    getAuthConfig: () => Promise.resolve({}),
   },
 }));
 
@@ -104,6 +104,28 @@ describe('mergePullRequest', () => {
         commitMessage: expect.stringContaining('[skip ci]'),
       }),
     );
+  });
+
+  test('when merge strategy is merge commit, its passed correctly', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+    const data = JSON.stringify({
+      close_source_branch: true,
+      message: `pull request #${landRequestStatus.request.pullRequestId} merged by Landkid after a successful build rebased on ${landRequestStatus.request.pullRequest.targetBranch}`,
+      merge_strategy: 'merge_commit',
+    });
+    await mergePullRequest(landRequestStatus, { mergeStrategy: 'merge-commit' });
+    expect(mockedAxios.post).toBeCalledWith(expect.any(String), data, {});
+  });
+
+  test('when merge strategy is squash, its passed correctly', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+    const data = JSON.stringify({
+      close_source_branch: true,
+      message: `pull request #${landRequestStatus.request.pullRequestId} merged by Landkid after a successful build rebased on ${landRequestStatus.request.pullRequest.targetBranch}`,
+      merge_strategy: 'squash',
+    });
+    await mergePullRequest(landRequestStatus, { mergeStrategy: 'squash' });
+    expect(mockedAxios.post).toBeCalledWith(expect.any(String), data, {});
   });
 
   test('Get task count, should call API and return the correct number of tasks UNRESOLVED', async () => {

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -77,6 +77,8 @@ declare interface ISessionUser {
 
 declare type IPermissionMode = 'read' | 'land' | 'admin';
 
+declare type IMergeStrategy = 'merge-commit' | 'squash';
+
 declare interface IPermission {
   aaid: string;
   dateAssigned: Date;

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,19 @@
     "@babel/runtime" "^7.0.0"
     "@emotion/core" "^10.0.9"
 
+"@atlaskit/checkbox@^12.3.19":
+  version "12.3.19"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/checkbox/-/checkbox-12.3.19.tgz#5b1b3313584690df06e0666462675e340c15f3b9"
+  integrity sha512-RJ+aLBkLFeWp/0vcKfdVflsl+pJRwHxvWOJYKDkXHOpuVles6JUlWJE/9GsKYESgEqJ47v+2Dhq5g/plVdt3mQ==
+  dependencies:
+    "@atlaskit/analytics-next" "^8.2.0"
+    "@atlaskit/ds-lib" "^2.1.0"
+    "@atlaskit/icon" "^21.10.0"
+    "@atlaskit/theme" "^12.1.0"
+    "@atlaskit/tokens" "^0.10.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/core" "^10.0.9"
+
 "@atlaskit/codemod-utils@^4.1.0":
   version "4.1.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/codemod-utils/-/codemod-utils-4.1.2.tgz#609a74fedf6574cdb126efcb98b8f23d6bbc5630"


### PR DESCRIPTION
This PR gives the users, ability to to squash merge the commits when landkid merges to master. 

## UI:
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/113331937/190129487-eaa5fc3d-dfc2-4a16-aef5-202c73674d53.png">

We enable the checkbox by default. Unchecking will result in a usual merge commit.

## Squashed commits in master:
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/113331937/190129734-c93f3693-2e5a-4526-afa9-6110d83dabdf.png">

## How is it done?
1. Add a new column `mergeStrategy` to `LandRequest` table.
2. Pass the user selection to to both `/land-when-able` and `/land` endpoints.
3. Store the `mergeStrategy` value in the DB
4. When the task is ready for merge, read the value from the DB and use that in Bitbucket pipelines API to decide merge strategy.
