### PR TITLE
Cut down on auto-refresh

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -28,6 +28,10 @@ module.exports = {
     },
   },
   maxConcurrentBuilds: 3,
+  widgetSettings: {
+    refreshInterval: 10000,
+    refreshOnlyWhenInViewport: false,
+  },
   prSettings: {
     requiredApprovals: 0,
     canApproveOwnPullRequest: true,

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -71,16 +71,15 @@ const App = () => {
   let refreshTimeoutId: Timeout;
 
   const pollAbleToLand = () => {
-    const isTabInForeground = !document.hidden;
-    let refreshIntervalMs = inViewRef.current ? 10000 : 20000;
+    const isInForeground = !document.hidden && inViewRef.current;
 
-    const checkPromise = isTabInForeground ? checkIfAbleToLand() : Promise.resolve();
+    const checkPromise = isInForeground ? checkIfAbleToLand() : Promise.resolve();
 
     checkPromise.finally(async () => {
       if (statusRef.current == 'pr-closed') return;
       refreshTimeoutId = setTimeout(() => {
         pollAbleToLand();
-      }, refreshIntervalMs);
+      }, 10000);
     });
   };
 

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -9,8 +9,8 @@ import { proxyRequest, proxyRequestBare } from '../utils/RequestProxy';
 import Message from './Message';
 import Timeout = NodeJS.Timeout;
 import { LoadStatus, QueueResponse, Status } from './types';
-import { WidgetSettings } from '../../../types';
 import getWidgetSettings from '../utils/getWidgetSettings';
+import { WidgetSettings } from '../../../types';
 
 type BannerMessage = {
   messageExists: boolean;
@@ -72,18 +72,24 @@ const App = () => {
 
   let refreshTimeoutId: Timeout;
 
+  // If only refreshing when in viewport, uses `refreshInterval`,
+  // Else uses `refreshInterval` when in viewport and twice the timeout when not in viewport
+  const getRefreshInterval = (widgetSettings: WidgetSettings) => {
+    if (widgetSettings.refreshOnlyWhenInViewport) {
+      return widgetSettings.refreshInterval;
+    } else {
+      return inViewRef.current
+        ? widgetSettings.refreshInterval
+        : widgetSettings.refreshInterval * 2;
+    }
+  };
+
   const pollAbleToLand = () => {
     const widgetSettings = getWidgetSettings();
     const isVisible =
       !document.hidden && (widgetSettings.refreshOnlyWhenInViewport ? inViewRef.current : true);
 
-    // If only refreshing when in viewport, uses `refreshInterval`,
-    // Else uses `refreshInterval` when in viewport and twice the timeout when not in viewport
-    let refreshIntervalMs = widgetSettings.refreshOnlyWhenInViewport
-      ? widgetSettings.refreshInterval
-      : inViewRef.current
-      ? widgetSettings.refreshInterval
-      : widgetSettings.refreshInterval * 2;
+    let refreshIntervalMs = getRefreshInterval(widgetSettings);
 
     const checkPromise = isVisible ? checkIfAbleToLand() : Promise.resolve();
 

--- a/src/static/bitbucket/index.ejs
+++ b/src/static/bitbucket/index.ejs
@@ -11,6 +11,9 @@
           Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       }
   </style>
+    <script>
+      window.__WIDGET_SETTINGS__ = <%= widgetSettings %>
+    </script>
 </head>
 <body>
 <div id="app" class="ac-content" style="min-height: 90px">

--- a/src/static/bitbucket/utils/getWidgetSettings.ts
+++ b/src/static/bitbucket/utils/getWidgetSettings.ts
@@ -2,8 +2,8 @@ import { WidgetSettings } from '../../../types';
 
 export default function getWidgetSettings(): WidgetSettings {
   return {
-    refreshInterval: 30000,
-    refreshOnlyWhenInViewport: true,
+    refreshInterval: 10000,
+    refreshOnlyWhenInViewport: false,
     // @ts-ignore -- this is a global variable that may be set by the server
     ...window.__WIDGET_SETTINGS__,
   };

--- a/src/static/bitbucket/utils/getWidgetSettings.ts
+++ b/src/static/bitbucket/utils/getWidgetSettings.ts
@@ -1,0 +1,10 @@
+import { WidgetSettings } from '../../../types';
+
+export default function getWidgetSettings(): WidgetSettings {
+  return {
+    refreshInterval: 30000,
+    refreshOnlyWhenInViewport: true,
+    // @ts-ignore -- this is a global variable that may be set by the server
+    ...window.__WIDGET_SETTINGS__,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,11 @@ type CustomRule = {
   };
 };
 
+export type WidgetSettings = {
+  refreshInterval: number;
+  refreshOnlyWhenInViewport: boolean;
+};
+
 export type PullRequestSettings = {
   requiredApprovals: number;
   requireClosedTasks: boolean;
@@ -89,6 +94,7 @@ export type Config = {
   baseUrl: string;
   landkidAdmins: string[];
   repoConfig: RepoConfig;
+  widgetSettings: WidgetSettings;
   prSettings: PullRequestSettings;
   deployment: DeploymentConfig;
   maxConcurrentBuilds?: number;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const config = require('./config');
 
 // This only really matters when building files, not in production
 const outputPath = process.env.OUTPUT_PATH || '.';
@@ -32,7 +33,7 @@ module.exports = {
     },
     client: {
       webSocketURL: fs.existsSync('./config.js')
-        ? require('./config').baseUrl.replace('https://', '')
+        ? config.baseUrl.replace('https://', '')
         : undefined,
     },
   },
@@ -69,7 +70,10 @@ module.exports = {
       filename: 'bitbucket/index.html',
       // only inject the code from the 'bitbucket' entry/chunk
       chunks: ['bitbucket'],
-      template: path.resolve(__dirname, './src/static/bitbucket/index.html'),
+      template: path.resolve(__dirname, './src/static/bitbucket/index.ejs'),
+      templateParameters: {
+        widgetSettings: JSON.stringify(config.widgetSettings || {}),
+      },
     }),
     new HtmlWebpackPlugin({
       filename: 'current-state/index.html',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const config = require('./config');
+
+const config = fs.existsSync('./config.js') ? require('./config') : null;
 
 // This only really matters when building files, not in production
 const outputPath = process.env.OUTPUT_PATH || '.';
@@ -32,9 +33,7 @@ module.exports = {
       '/ac': `http://localhost:${SERVER_PORT}`,
     },
     client: {
-      webSocketURL: fs.existsSync('./config.js')
-        ? config.baseUrl.replace('https://', '')
-        : undefined,
+      webSocketURL: config ? config.baseUrl.replace('https://', '') : undefined,
     },
   },
   module: {
@@ -72,7 +71,7 @@ module.exports = {
       chunks: ['bitbucket'],
       template: path.resolve(__dirname, './src/static/bitbucket/index.ejs'),
       templateParameters: {
-        widgetSettings: JSON.stringify(config.widgetSettings || {}),
+        widgetSettings: JSON.stringify(config?.widgetSettings || {}),
       },
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Don't auto refresh when not in view — previously we'd auto-refresh if the widget was not in the viewport, albeit at a much slower rate.