### PR TITLE
[Ready] Use an endpoint for widget settings

### DIFF
--- a/src/bitbucket/descriptor.ts
+++ b/src/bitbucket/descriptor.ts
@@ -45,6 +45,9 @@ export const makeDescriptor = () => {
           destination:
             '/bitbucket/proxy/can-land?aaid={user.uuid}&pullRequestId={pullrequest.id}&accountId={user.account_id}&sourceBranch={pullrequest.source.branch.name}&destinationBranch={pullrequest.destination.branch.name}',
         },
+        '/settings': {
+          destination: '/bitbucket/proxy/settings',
+        },
         '/queue': {
           destination: '/bitbucket/proxy/queue',
         },

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -118,6 +118,13 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
   );
 
   router.post(
+    '/settings',
+    wrap(async (req, res) => {
+      return res.json(config ? config.widgetSettings : {});
+    }),
+  );
+
+  router.post(
     '/land',
     wrap(async (req, res) => {
       const { aaid, pullRequestId, commit, accountId } = req.query as Record<string, string>;

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -9,8 +9,7 @@ import { proxyRequest, proxyRequestBare } from '../utils/RequestProxy';
 import Message from './Message';
 import Timeout = NodeJS.Timeout;
 import { LoadStatus, QueueResponse, Status } from './types';
-import getWidgetSettings from '../utils/getWidgetSettings';
-import { WidgetSettings } from '../../../types';
+import useWidgetSettings from '../utils/getWidgetSettings';
 
 type BannerMessage = {
   messageExists: boolean;
@@ -56,6 +55,7 @@ const App = () => {
   const [queue, setQueue] = useState<QueueResponse['queue'] | undefined>();
   const [_, setLoadStatus, loadStatusRef] = useState<LoadStatus>('not-loaded');
   const [state, dispatch] = useState(initialState);
+  const widgetSettings = useWidgetSettings();
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -74,7 +74,7 @@ const App = () => {
 
   // If only refreshing when in viewport, uses `refreshInterval`,
   // Else uses `refreshInterval` when in viewport and twice the timeout when not in viewport
-  const getRefreshInterval = (widgetSettings: WidgetSettings) => {
+  const getRefreshInterval = () => {
     if (widgetSettings.refreshOnlyWhenInViewport) {
       return widgetSettings.refreshInterval;
     } else {
@@ -85,11 +85,10 @@ const App = () => {
   };
 
   const pollAbleToLand = () => {
-    const widgetSettings = getWidgetSettings();
     const isVisible =
       !document.hidden && (widgetSettings.refreshOnlyWhenInViewport ? inViewRef.current : true);
 
-    let refreshIntervalMs = getRefreshInterval(widgetSettings);
+    let refreshIntervalMs = getRefreshInterval();
 
     const checkPromise = isVisible ? checkIfAbleToLand() : Promise.resolve();
 

--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -56,6 +56,11 @@ const App = () => {
   const [_, setLoadStatus, loadStatusRef] = useState<LoadStatus>('not-loaded');
   const [state, dispatch] = useState(initialState);
   const widgetSettings = useWidgetSettings();
+  const widgetSettingsRef = useRef(widgetSettings);
+
+  if (widgetSettings !== widgetSettingsRef.current) {
+    widgetSettingsRef.current = widgetSettings;
+  }
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -75,18 +80,19 @@ const App = () => {
   // If only refreshing when in viewport, uses `refreshInterval`,
   // Else uses `refreshInterval` when in viewport and twice the timeout when not in viewport
   const getRefreshInterval = () => {
-    if (widgetSettings.refreshOnlyWhenInViewport) {
-      return widgetSettings.refreshInterval;
+    if (widgetSettingsRef.current.refreshOnlyWhenInViewport) {
+      return widgetSettingsRef.current.refreshInterval;
     } else {
       return inViewRef.current
-        ? widgetSettings.refreshInterval
-        : widgetSettings.refreshInterval * 2;
+        ? widgetSettingsRef.current.refreshInterval
+        : widgetSettingsRef.current.refreshInterval * 2;
     }
   };
 
   const pollAbleToLand = () => {
     const isVisible =
-      !document.hidden && (widgetSettings.refreshOnlyWhenInViewport ? inViewRef.current : true);
+      !document.hidden &&
+      (widgetSettingsRef.current.refreshOnlyWhenInViewport ? inViewRef.current : true);
 
     let refreshIntervalMs = getRefreshInterval();
 

--- a/src/static/bitbucket/index.html
+++ b/src/static/bitbucket/index.html
@@ -11,9 +11,6 @@
           Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       }
   </style>
-    <script>
-      window.__WIDGET_SETTINGS__ = <%= widgetSettings %>
-    </script>
 </head>
 <body>
 <div id="app" class="ac-content" style="min-height: 90px">

--- a/src/static/bitbucket/utils/getWidgetSettings.ts
+++ b/src/static/bitbucket/utils/getWidgetSettings.ts
@@ -1,10 +1,25 @@
 import { WidgetSettings } from '../../../types';
+import { proxyRequestBare } from './RequestProxy';
+import useState from 'react-usestateref';
+import { useEffect } from 'react';
 
-export default function getWidgetSettings(): WidgetSettings {
-  return {
-    refreshInterval: 10000,
-    refreshOnlyWhenInViewport: false,
-    // @ts-ignore -- this is a global variable that may be set by the server
-    ...window.__WIDGET_SETTINGS__,
-  };
+const defaultSettings = {
+  refreshInterval: 10000,
+  refreshOnlyWhenInViewport: false,
+};
+
+export default function useWidgetSettings(): WidgetSettings {
+  const [widgetSettings, setWidgetSettings] = useState<WidgetSettings>(defaultSettings);
+
+  useEffect(() => {
+    proxyRequestBare<any>('/settings', 'POST')
+      .then((settings) => {
+        setWidgetSettings({ ...defaultSettings, ...settings });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }, []);
+
+  return widgetSettings;
 }

--- a/src/static/bitbucket/utils/getWidgetSettings.ts
+++ b/src/static/bitbucket/utils/getWidgetSettings.ts
@@ -1,7 +1,6 @@
 import { WidgetSettings } from '../../../types';
 import { proxyRequestBare } from './RequestProxy';
-import useState from 'react-usestateref';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const defaultSettings = {
   refreshInterval: 10000,
@@ -12,7 +11,7 @@ export default function useWidgetSettings(): WidgetSettings {
   const [widgetSettings, setWidgetSettings] = useState<WidgetSettings>(defaultSettings);
 
   useEffect(() => {
-    proxyRequestBare<any>('/settings', 'POST')
+    proxyRequestBare<WidgetSettings>('/settings', 'POST')
       .then((settings) => {
         setWidgetSettings({ ...defaultSettings, ...settings });
       })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const config = fs.existsSync('./config.js') ? require('./config') : null;
-
 // This only really matters when building files, not in production
 const outputPath = process.env.OUTPUT_PATH || '.';
 const SERVER_PORT = process.env.SERVER_PORT || '8080';
@@ -33,7 +31,9 @@ module.exports = {
       '/ac': `http://localhost:${SERVER_PORT}`,
     },
     client: {
-      webSocketURL: config ? config.baseUrl.replace('https://', '') : undefined,
+      webSocketURL: fs.existsSync('./config.js')
+        ? require('./config').baseUrl.replace('https://', '')
+        : undefined,
     },
   },
   module: {
@@ -69,10 +69,7 @@ module.exports = {
       filename: 'bitbucket/index.html',
       // only inject the code from the 'bitbucket' entry/chunk
       chunks: ['bitbucket'],
-      template: path.resolve(__dirname, './src/static/bitbucket/index.ejs'),
-      templateParameters: {
-        widgetSettings: JSON.stringify(config?.widgetSettings || {}),
-      },
+      template: path.resolve(__dirname, './src/static/bitbucket/index.html'),
     }),
     new HtmlWebpackPlugin({
       filename: 'current-state/index.html',


### PR DESCRIPTION
My [previous attempt](https://github.com/atlassian/landkid/pull/181) to expose dynamic settings to the widget was un-successful. This is because `config.js` is essentially not used at build time (it is, but only for webpack dev server), and only powers the node server configuration.

Instead, I now fetch settings through a new server endpoint now. It is a bit of an overkill, but should allow us to set to tweak settings for the widget internally without needing to make and publish new landkid images in the future.

