### PR TITLE
Clear timeouts before setting a new one

### DIFF
--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -100,6 +100,9 @@ const App = () => {
 
     checkPromise.finally(async () => {
       if (statusRef.current == 'pr-closed') return;
+      if(refreshTimeoutId) {
+        clearTimeout(refreshTimeoutId);
+      }  
       refreshTimeoutId = setTimeout(() => {
         pollAbleToLand();
       }, refreshIntervalMs);


### PR DESCRIPTION
Ideally given that I add a timeout to the daisy chain only after the previous one has expired, there shouldn't be timeouts running in parallel.  But I want to clear older timeouts here — just as a good practice and a remote chance that we had irregular re-renders setting up additional timeouts.