### PR TITLE
Not conflicting if we cannot process diffstat

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -181,12 +181,17 @@ export class BitbucketAPI {
 
   pullRequestHasConflicts = async (source: string, destination: string): Promise<boolean> => {
     const endpoint = `${this.baseUrl}/diffstat/${source}..${destination}?merge=true&fields=values.status`;
-    const resp = await axios.get<BB.DiffStatResponse>(
-      endpoint,
-      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
-    );
-    const data = resp.data;
-    return data.values.some((diff) => diff.status === 'merge conflict');
+    try {
+      const resp = await axios.get<BB.DiffStatResponse>(
+        endpoint,
+        await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
+      );
+      const data = resp.data;
+      return data.values.some((diff) => diff.status === 'merge conflict');
+    } catch (e) {
+      // It's possible that the source branch has been deleted, in which case we can't check for conflicts
+      return false;
+    }
   };
 
   getPullRequestBuildStatuses = async (pullRequestId: number): Promise<Array<BB.BuildStatus>> => {


### PR DESCRIPTION
In case we cannot fetch diffstat for conflict checking, we'll assume that there were no conflicts — since it is possible for diffstat to fail when a PR has already been merged.