### PR TITLE
Allow land button even when in queued state

### DIFF
--- a/src/static/bitbucket/components/App.tsx
+++ b/src/static/bitbucket/components/App.tsx
@@ -227,6 +227,7 @@ const App = () => {
         queue={queue}
         status={status}
         canLandWhenAble={state.canLandWhenAble}
+        canLand={state.canLand}
         errors={state.errors}
         warnings={state.warnings}
         bannerMessage={state.bannerMessage}

--- a/src/static/bitbucket/components/Message.tsx
+++ b/src/static/bitbucket/components/Message.tsx
@@ -64,6 +64,7 @@ type MessageProps = {
   onLandClicked: () => void;
   onLandWhenAbleClicked: () => void;
   onCheckAgainClicked: () => void;
+  canLand: boolean;
   canLandWhenAble: boolean;
   errors: string[];
   warnings: string[];
@@ -146,6 +147,7 @@ const Message = ({
   onLandWhenAbleClicked,
   onCheckAgainClicked,
   canLandWhenAble,
+  canLand,
   errors,
   warnings,
   bannerMessage,
@@ -231,7 +233,7 @@ const Message = ({
   const showErrors =
     status === 'cannot-land' || status === 'queued' || status == 'will-queue-when-ready';
 
-  const landButton = (
+  const getLandButton = (label: string) => (
     <div style={{ marginRight: 15 }}>
       <Confetti
         active={loadStatus === 'queuing'}
@@ -251,7 +253,7 @@ const Message = ({
         }}
       />
       <Button appearance="primary" onClick={onLandClicked} isLoading={loadStatus === 'queuing'}>
-        Land changes
+        {label}
       </Button>
     </div>
   );
@@ -260,7 +262,7 @@ const Message = ({
     const actions = [];
     switch (status) {
       case 'can-land':
-        actions.push(landButton);
+        actions.push(getLandButton('Land changes'));
         break;
       case 'running':
       case 'queued':
@@ -272,6 +274,10 @@ const Message = ({
         );
         break;
       case 'will-queue-when-ready':
+        if (canLand) {
+          actions.push(getLandButton('Land immediately'));
+        }
+
         actions.push(
           <SectionMessageAction onClick={onCheckAgainClicked}>Check again</SectionMessageAction>,
         );


### PR DESCRIPTION
Previously, we wouldn't show a land button when the PR was in "Queued for land" state. It was expected that the Landkid poller would anyways land the PR when ready.

But it turns out that we only look at land requests in the last 7 days for polling. This means its possible for a PR to go into a "stuck" state, where it becomes "landable" after 7 days, but is still in "Queued for land".

Now ideally, after 7 days, we should mark land requests in "Queued for land" back to the default state, so this problem of stuck PRs does not arise.

But as immediate mitigation, I'm adding back the land button to the "Queued for land" in case the PR is landable.
This will also allow you to skip the 2-minute poll time if you wish and land changes immediately.