### PR TITLE
Add merge checks error messages to reason

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -9,9 +9,18 @@ import { BitbucketMerger } from './BitbucketMerger';
 
 const BBAPIBaseUrl = 'https://api.bitbucket.org/2.0/repositories';
 
+type Reason = {
+  error: {
+    fields?: {
+      merge_checks?: string[];
+    };
+    message?: string;
+  };
+};
+
 type MergePullRequestResult = {
   status: string;
-  reason?: any;
+  reason?: Reason;
 };
 
 export class BitbucketAPI {

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -11,7 +11,7 @@ const BBAPIBaseUrl = 'https://api.bitbucket.org/2.0/repositories';
 
 type MergePullRequestResult = {
   status: string;
-  reason?: string;
+  reason?: any;
 };
 
 export class BitbucketAPI {
@@ -64,7 +64,7 @@ export class BitbucketAPI {
         landRequestId,
         landRequestStatus,
       });
-      return { status: BitbucketAPI.FAILED, reason: data?.error?.message || statusText };
+      return { status: BitbucketAPI.FAILED, reason: data };
     };
 
     const onMergeAbort = () => {

--- a/src/bitbucket/__tests__/BitbucketAPI.test.ts
+++ b/src/bitbucket/__tests__/BitbucketAPI.test.ts
@@ -66,10 +66,34 @@ describe('mergePullRequest', () => {
     mockedAxios.post.mockResolvedValue({ status: 500, data: { error: { message: 'reason' } } });
     expect(await mergePullRequest(landRequestStatus)).toStrictEqual({
       status: BitbucketAPI.FAILED,
-      reason: 'reason',
+      reason: { error: { message: 'reason' } },
     });
   });
 
+  test('merge failure with message containing fields with merge_checks ', async () => {
+    mockedAxios.post.mockResolvedValue({
+      status: 400,
+      data: {
+        error: {
+          fields: {
+            merge_checks: ['At least 1 approval', 'No in progress builds on last commit'],
+          },
+          message: '2 failed merge checks',
+        },
+      },
+    });
+    expect(await mergePullRequest(landRequestStatus)).toStrictEqual({
+      status: BitbucketAPI.FAILED,
+      reason: {
+        error: {
+          fields: {
+            merge_checks: ['At least 1 approval', 'No in progress builds on last commit'],
+          },
+          message: '2 failed merge checks',
+        },
+      },
+    });
+  });
   test('Successful timeout merge', async () => {
     mockedAxios.post.mockResolvedValue({ status: 202, headers: { location: '' } });
     mockedAxios.get

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -270,14 +270,12 @@ export class Runner {
             targetBranch: pullRequest.targetBranch,
           });
 
-          const hasErrors = result.reason && result.reason.error;
-          const mergeCheckErrors =
-            hasErrors && result.reason.error.fields
-              ? ' ' + result.reason.error.fields.merge_checks.join(', ')
-              : '';
-          const error = hasErrors ? result.reason.error.message + '. ' + mergeCheckErrors : '';
-
-          await landRequest.setStatus('fail', 'Unable to merge pull request: ' + error);
+          await landRequest.setStatus(
+            'fail',
+            `Unable to merge pull request: ${result.reason?.error?.message}. ${
+              result.reason?.error?.fields?.merge_checks?.join(', ') ?? ''
+            }`,
+          );
         } else if (result.status === BitbucketAPI.ABORTED) {
           eventEmitter.emit('PULL_REQUEST.MERGE.ABORT', {
             landRequestId: landRequestStatus.requestId,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -269,10 +269,15 @@ export class Runner {
             sourceBranch: pullRequest.sourceBranch,
             targetBranch: pullRequest.targetBranch,
           });
-          await landRequest.setStatus(
-            'fail',
-            `Unable to merge pull request ${result.reason ? `: ${result.reason}` : ''}`,
-          );
+
+          const hasErrors = result.reason && result.reason.error;
+          const mergeCheckErrors =
+            hasErrors && result.reason.error.fields
+              ? ' ' + result.reason.error.fields.merge_checks.join(', ')
+              : '';
+          const error = hasErrors ? result.reason.error.message + '. ' + mergeCheckErrors : '';
+
+          await landRequest.setStatus('fail', 'Unable to merge pull request: ' + error);
         } else if (result.status === BitbucketAPI.ABORTED) {
           eventEmitter.emit('PULL_REQUEST.MERGE.ABORT', {
             landRequestId: landRequestStatus.requestId,

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -30,7 +30,7 @@ const queueItemStyles = css({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
-    marginBottom: '3px',
+    marginBottom: '10px',
   },
 
   '& .queue-item__status-line': {
@@ -38,14 +38,16 @@ const queueItemStyles = css({
     flexGrow: 1,
     flexWrap: 'nowrap',
     marginTop: 'auto',
-    height: '28px',
+    marginBottom: '5px',
   },
 
   '& .queue-item__status-item': {
     display: 'inline-flex',
     flexDirection: 'row',
     alignItems: 'center',
-    height: '28px',
+    height: '2.5%',
+    flexWrap: 'nowrap',
+    marginBottom: '5px',
 
     '& + .queue-item__status-item': {
       marginLeft: '9px',
@@ -69,9 +71,9 @@ const queueItemStyles = css({
 
   '& .queue-item__more-info': {
     marginRight: '8px',
-    overflowY: 'hidden',
-    overflowX: 'scroll',
-    whiteSpace: 'nowrap',
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
 
     '&::-webkit-scrollbar': {
       display: 'none',
@@ -275,7 +277,9 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
         </div>
         {status.reason && status.state !== 'queued' ? (
           <div className="queue-item__status-line">
-            <StatusItem title="Reason:">{status.reason}</StatusItem>
+            <StatusItem title="Reason:">
+              <span>{status.reason}</span>
+            </StatusItem>
           </div>
         ) : null}
         {status.request.triggererAaid ? (


### PR DESCRIPTION
Adding on to improving the reason messaging for failed landkid attempts. 

When we get a "Unable to merge pull request" error, there are failed merge checks fields given in the error logs. Adding this to the reason could be useful for users to know.

<img width="436" alt="image" src="https://user-images.githubusercontent.com/19305535/195463272-fd6d74b3-e042-4beb-b4ad-1dc090b366c6.png">

<img width="972" alt="image" src="https://user-images.githubusercontent.com/19305535/195463073-8ee09467-9953-4cd2-8bac-92657c02f2ef.png">

For long reason messages that extend the width
![image](https://user-images.githubusercontent.com/19305535/195737945-a527501d-3b20-498b-b35f-ab679dbe432b.png)
