### PR TITLE
MONO-24 Updated PR priority during land-request.

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -234,7 +234,7 @@ export class BitbucketAPI {
 
     const priority =
       allBuildStatuses.find((buildStatus) => buildStatus.name === 'landkid-priority')
-        ?.description || 'HIGH';
+        ?.description || 'LOW';
 
     Logger.info('PR priority', {
       namespace: 'bitbucket:api:getPullRequestPriority',

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -223,6 +223,28 @@ export class BitbucketAPI {
       }));
   };
 
+  getPullRequestPriority = async (commit: string): Promise<BB.PRPriority> => {
+    const endpoint = `${this.baseUrl}/commit/${commit}/statuses`;
+    const { data } = await axios.get<{ values: BB.BuildPriorityResponse[] }>(
+      endpoint,
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
+    );
+
+    const allBuildStatuses = data.values;
+
+    const priority =
+      allBuildStatuses.find((buildStatus) => buildStatus.name === 'landkid-priority')
+        ?.description || 'HIGH';
+
+    Logger.info('PR priority', {
+      namespace: 'bitbucket:api:getPullRequestPriority',
+      commit,
+      priority,
+    });
+
+    return priority;
+  };
+
   getUser = async (aaid: string): Promise<ISessionUser> => {
     const endpoint = `https://api.bitbucket.org/2.0/users/${aaid}`;
     const resp = await axios.get(

--- a/src/bitbucket/__tests__/BitbucketAPI.test.ts
+++ b/src/bitbucket/__tests__/BitbucketAPI.test.ts
@@ -171,3 +171,30 @@ describe('mergePullRequest', () => {
     expect(taskCount).toEqual(1);
   });
 });
+
+describe('getPullRequestPriority', () => {
+  test('when build status includes "landkid-priority" then should return priority ', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        values: [
+          {
+            name: 'landkid-priority',
+            description: 'HIGH',
+          },
+        ],
+      },
+    });
+
+    expect(await bitbucketAPI.getPullRequestPriority('commit-foo')).toBe('HIGH');
+  });
+
+  test('when build status doesn"t include "landkid-priority" then should return default priority ', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        values: [],
+      },
+    });
+
+    expect(await bitbucketAPI.getPullRequestPriority('commit-foo')).toBe('LOW');
+  });
+});

--- a/src/bitbucket/types.d.ts
+++ b/src/bitbucket/types.d.ts
@@ -137,6 +137,13 @@ declare namespace BB {
 
   type BuildState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS' | 'STOPPED' | 'DEFAULT' | 'PENDING';
 
+  type PRPriority = 'LOW' | 'HIGH';
+
+  type BuildPriorityResponse = {
+    name: string;
+    description: PRPriority;
+  };
+
   type BuildStatus = {
     name: string;
     state: BuildState;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -547,6 +547,11 @@ export class Runner {
 
     const { request } = landRequestStatus;
 
+    const priority = await this.client.bitbucket.getPullRequestPriority(request.forCommit);
+    if (priority === 'HIGH') {
+      await request.incrementPriority();
+    }
+
     const user = await this.client.getUser(request.triggererAaid);
     await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
 


### PR DESCRIPTION
**What's changed ?**
- During landing request verify if the commit build statuses for `landkid-priority` metadata.
- Increment the priority of the PR based on `landkid-priority`.


**Verfication**
Verified the changes on test repo. Need to perform e2e testing of the flow.