### PR TITLE
Add duration fields to LAND_REQUEST.STATUS.CHANGED event

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -148,6 +148,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
       prevState: prevStatus?.state,
       stateDuration: prevStatus ? Date.now() - prevStatus.date.getTime() : null,
       durationSinceQueued: queuedDate ? Date.now() - queuedDate.getTime() : null,
+      dependsOn: this.dependsOn,
     });
     return true;
   };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -82,10 +82,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   @AllowNull(true)
   @Column(
     Sequelize.ENUM({
-      values: [
-        'squash',
-        'merge-commit',
-      ],
+      values: ['squash', 'merge-commit'],
     }),
   )
   mergeStrategy: IMergeStrategy;
@@ -135,6 +132,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
         { transaction: t },
       );
     });
+    const queuedDate = await this.getQueuedDate();
     eventEmitter.emit('LAND_REQUEST.STATUS.CHANGED', {
       landRequestId: this.id,
       pullRequestId: this.pullRequestId,
@@ -148,6 +146,8 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
       state,
       reason,
       prevState: prevStatus?.state,
+      stateDuration: prevStatus ? Date.now() - prevStatus.date.getTime() : null,
+      durationSinceQueued: queuedDate ? Date.now() - queuedDate.getTime() : null,
     });
     return true;
   };
@@ -204,6 +204,17 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
 
   decrementPriority = () => {
     return this.updatePriority(this.priority - 1);
+  };
+
+  getQueuedDate = async () => {
+    const status = await LandRequestStatus.findOne<LandRequestStatus>({
+      where: {
+        requestId: this.id,
+        state: 'queued',
+      },
+      order: [['date', 'ASC']],
+    });
+    return status ? status.date : null;
   };
 }
 

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -250,7 +250,7 @@ export class Runner {
       .then(async (result) => {
         if (result.status === BitbucketAPI.SUCCESS) {
           const end = Date.now();
-          const queuedDate = await this.getLandRequestQueuedDate(landRequest.id);
+          const queuedDate = await landRequest.getQueuedDate();
           const start = queuedDate!.getTime();
           eventEmitter.emit('PULL_REQUEST.MERGE.SUCCESS', {
             landRequestId: landRequestStatus.requestId,
@@ -654,17 +654,6 @@ export class Runner {
       statuses[requestId] = landRequestStatuses;
     }
     return statuses;
-  };
-
-  getLandRequestQueuedDate = async (requestId: string): Promise<Date | null> => {
-    const status = await LandRequestStatus.findOne<LandRequestStatus>({
-      where: {
-        requestId,
-        state: 'queued',
-      },
-      order: [['date', 'ASC']],
-    });
-    return status ? status.date : null;
   };
 
   getLandRequestStateByPRId = async (pullRequestId: number): Promise<LandRequestStatus | null> => {


### PR DESCRIPTION
These can be used to track how long each status transition takes as well as how long it has been since the request was originally queued.