### PR TITLE
Only check for changed target branch when destinationBranch is supplied

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -789,7 +789,7 @@ export class Runner {
 
     const abortErrors: string[] = [];
 
-    if (isAllowedToMerge.pullRequest.targetBranch !== destinationBranch) {
+    if (destinationBranch && destinationBranch !== isAllowedToMerge.pullRequest.targetBranch) {
       Logger.warn('Target branch changed after landing', {
         namespace: 'lib:runner:isAllowedToLand',
         pullRequestId: pullRequestId,


### PR DESCRIPTION
This guards against a missing destinationBranch preventing users from landing. This can occur with an outdated ac descriptor that has not specified the destination branch as a query parameter to the `can-land` endpoint.