### PR TITLE
New API route updates to assist with e2e tests

### DIFF
--- a/src/lib/StateService.ts
+++ b/src/lib/StateService.ts
@@ -7,6 +7,7 @@ import {
 } from '../db';
 import { State } from '../types';
 import { config } from './Config';
+import { Logger } from './Logger';
 
 export class StateService {
   constructor() {}
@@ -51,10 +52,22 @@ export class StateService {
   }
 
   static async updateMaxConcurrentBuild(maxConcurrentBuilds: number, user: ISessionUser) {
-    await ConcurrentBuildState.create<ConcurrentBuildState>({
-      adminAaid: user.aaid,
-      maxConcurrentBuilds,
-    });
+    try {
+      await ConcurrentBuildState.create<ConcurrentBuildState>({
+        adminAaid: user.aaid,
+        maxConcurrentBuilds,
+      });
+      return true;
+    } catch (error) {
+      Logger.error('Error updating max concurrency', {
+        namespace: 'lib:stateService:updateMaxConcurrentBuild',
+        maxConcurrentBuilds,
+        error,
+        errorString: String(error),
+        errorStack: String(error.stack),
+      });
+      return false;
+    }
   }
 
   /**
@@ -95,8 +108,16 @@ export class StateService {
         adminAaid: user.aaid,
         branchName,
       });
-    } catch (e) {
-      console.log(`Error adding priority branch: ${e}`);
+      return true;
+    } catch (error) {
+      Logger.error('Error adding priority branch', {
+        namespace: 'lib:stateService:addPriorityBranch',
+        branchName,
+        error,
+        errorString: String(error),
+        errorStack: String(error.stack),
+      });
+      return false;
     }
   }
 
@@ -107,8 +128,32 @@ export class StateService {
           branchName: branchName,
         },
       });
-    } catch (e) {
-      console.log(`Error removing priority branch: ${e}`);
+      return true;
+    } catch (error) {
+      Logger.error('Error removing priority branch', {
+        namespace: 'lib:stateService:removePriorityBranch',
+        branchName,
+        error,
+        errorString: String(error),
+        errorStack: String(error.stack),
+      });
+      return false;
+    }
+  }
+
+  // Used for end to end testing
+  static async removeAllPriorityBranches() {
+    try {
+      await PriorityBranch.truncate();
+      return true;
+    } catch (error) {
+      Logger.error('Error removing all priority branches', {
+        namespace: 'lib:stateService:removeAllPriorityBranches',
+        error,
+        errorString: String(error),
+        errorStack: String(error.stack),
+      });
+      return false;
     }
   }
 
@@ -122,8 +167,16 @@ export class StateService {
           },
         },
       );
-    } catch (e) {
-      console.log(`Error updating priority branch: ${e}`);
+      return true;
+    } catch (error) {
+      Logger.error('Error updating priority branch', {
+        namespace: 'lib:stateService:updatePriorityBranch',
+        branchName,
+        error,
+        errorString: String(error),
+        errorStack: String(error.stack),
+      });
+      return false;
     }
   }
 

--- a/src/lib/__mocks__/StateService.ts
+++ b/src/lib/__mocks__/StateService.ts
@@ -2,6 +2,7 @@ const MockedStateServiceModule: any = jest.genMockFromModule('../StateService');
 
 export const StateService = MockedStateServiceModule.StateService;
 
+StateService.updateMaxConcurrentBuild.mockResolvedValue(true);
 StateService.getMaxConcurrentBuilds.mockResolvedValue(2);
 StateService.getPauseState.mockResolvedValue(null);
 StateService.getBannerMessageState.mockResolvedValue(null);
@@ -27,3 +28,5 @@ StateService.getState.mockResolvedValue({
     },
   ],
 });
+StateService.addPriorityBranch.mockResolvedValue(true);
+StateService.removePriorityBranch.mockResolvedValue(true);

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -149,8 +149,12 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       });
 
       if (typeof maxConcurrentBuilds == 'number' && maxConcurrentBuilds > 0) {
-        StateService.updateMaxConcurrentBuild(maxConcurrentBuilds, req.user!);
-        return res.status(200).json({ success: true });
+        const success = await StateService.updateMaxConcurrentBuild(maxConcurrentBuilds, req.user!);
+        if (success) {
+          return res.status(200).json({ success: true });
+        } else {
+          return res.sendStatus(500);
+        }
       }
 
       return res
@@ -171,8 +175,12 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       Logger.verbose(`Adding priority branch ${branchName}`, {
         namespace: 'routes:api:add-priority-branch',
       });
-      StateService.addPriorityBranch(branchName, req.user!);
-      res.status(200).json({ message: `${branchName} successfully added.` });
+      const success = await StateService.addPriorityBranch(branchName, req.user!);
+      if (success) {
+        res.status(200).json({ message: `${branchName} successfully added.` });
+      } else {
+        res.sendStatus(500);
+      }
     }),
   );
 
@@ -187,8 +195,12 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       Logger.verbose(`Removing priority branch ${branchName}`, {
         namespace: 'routes:api:remove-priority-branch',
       });
-      StateService.removePriorityBranch(branchName);
-      res.status(200).json({ message: `${branchName} successfully removed.` });
+      const success = await StateService.removePriorityBranch(branchName);
+      if (success) {
+        res.status(200).json({ message: `${branchName} successfully removed.` });
+      } else {
+        res.sendStatus(500);
+      }
     }),
   );
 
@@ -208,8 +220,28 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
         namespace: 'routes:api:update-priority-branch',
       });
 
-      StateService.updatePriorityBranch(id, branchName);
-      res.status(200).json({ message: `${branchName} successfully updated.` });
+      const success = await StateService.updatePriorityBranch(id, branchName);
+      if (success) {
+        res.status(200).json({ message: `${branchName} successfully updated.` });
+      } else {
+        res.sendStatus(500);
+      }
+    }),
+  );
+
+  router.post(
+    '/remove-all-priority-branches',
+    requireAuth('admin'),
+    wrap(async (req, res) => {
+      Logger.verbose(`Removing all priority branches`, {
+        namespace: 'routes:api:remove-priority-branch',
+      });
+      const success = await StateService.removeAllPriorityBranches();
+      if (success) {
+        res.status(200).json({ message: `All branches successfully removed.` });
+      } else {
+        res.sendStatus(500);
+      }
     }),
   );
 

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -234,7 +234,7 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       Logger.verbose(`Removing all priority branches`, {
-        namespace: 'routes:api:remove-priority-branch',
+        namespace: 'routes:api:remove-all-priority-branches',
       });
       const success = await StateService.removeAllPriorityBranches();
       if (success) {

--- a/src/routes/api/test.ts
+++ b/src/routes/api/test.ts
@@ -34,7 +34,7 @@ describe('API Routes', () => {
       failBuildHandler = async (req: Function) => {
         const handler = failBuildRoute && failBuildRoute[2];
         if (!handler) return;
-        handler(req, mockResponse, () => {});
+        return handler(req, mockResponse, () => {});
       };
     });
     it('should be registered', async () => {
@@ -84,7 +84,7 @@ describe('API Routes', () => {
       updateConcurrentBuildHandler = async (req: Function) => {
         const handler = updateConcurrentBuildRoute && updateConcurrentBuildRoute[2];
         if (!handler) return;
-        handler(req, mockResponse, () => {});
+        return handler(req, mockResponse, () => {});
       };
     });
     it('should be registered', async () => {
@@ -128,7 +128,6 @@ describe('API Routes', () => {
 
     it('should update concurrent builds slots', async () => {
       expect(StateService.updateMaxConcurrentBuild).not.toHaveBeenCalled();
-      expect(mockRunner.onStatusUpdate).not.toHaveBeenCalled();
       expect(mockResponse.status).not.toHaveBeenCalled();
       expect(mockResponse.json).not.toHaveBeenCalled();
       await updateConcurrentBuildHandler(
@@ -147,6 +146,26 @@ describe('API Routes', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(200);
       expect(mockResponse.json).toHaveBeenCalledWith({ success: true });
     });
+
+    it('should return 500 on unexpected failure', async () => {
+      expect(StateService.updateMaxConcurrentBuild).not.toHaveBeenCalled();
+      expect(mockResponse.sendStatus).not.toHaveBeenCalled();
+      (StateService.updateMaxConcurrentBuild as jest.Mock).mockResolvedValueOnce(false);
+      await updateConcurrentBuildHandler(
+        {
+          body: {
+            maxConcurrentBuilds: 3,
+          },
+          user: { aaid: 'mock-user-aaid' },
+        },
+        mockExpress.response,
+        () => {},
+      );
+      expect(StateService.updateMaxConcurrentBuild).toHaveBeenCalledWith(3, {
+        aaid: 'mock-user-aaid',
+      });
+      expect(mockResponse.sendStatus).toHaveBeenCalledWith(500);
+    });
   });
 
   describe('/add-priority-branch', () => {
@@ -159,7 +178,7 @@ describe('API Routes', () => {
       addPriorityBranchHandler = async (req: Function) => {
         const handler = addPriorityBranchRoute && addPriorityBranchRoute[2];
         if (!handler) return;
-        handler(req, mockResponse, () => {});
+        return handler(req, mockResponse, () => {});
       };
     });
     it('should be registered', async () => {
@@ -178,9 +197,6 @@ describe('API Routes', () => {
       );
     });
     it('should succeed when branchName and user is provided', async () => {
-      jest.spyOn(StateService, 'addPriorityBranch');
-      expect(mockRunner.onStatusUpdate).not.toHaveBeenCalled();
-      expect(mockResponse.sendStatus).not.toHaveBeenCalled();
       await addPriorityBranchHandler(
         {
           body: {
@@ -199,6 +215,23 @@ describe('API Routes', () => {
       );
       expect(mockResponse.status).toHaveBeenCalledWith(200);
     });
+    it('should return 500 on unexpected failure', async () => {
+      (StateService.addPriorityBranch as jest.Mock).mockResolvedValueOnce(false);
+      await addPriorityBranchHandler(
+        {
+          body: {
+            branchName: 'test/test-branch',
+          },
+          user: { aaid: 'mock-user-aaid' },
+        },
+        mockExpress.response,
+        () => {},
+      );
+      expect(StateService.addPriorityBranch).toHaveBeenCalledWith('test/test-branch', {
+        aaid: 'mock-user-aaid',
+      });
+      expect(mockResponse.sendStatus).toHaveBeenCalledWith(500);
+    });
   });
   describe('/remove-priority-branch', () => {
     let removePriorityBranchRoute: [string, ...Function[]];
@@ -210,7 +243,7 @@ describe('API Routes', () => {
       removePriorityBranchHandler = async (req: Function) => {
         const handler = removePriorityBranchRoute && removePriorityBranchRoute[2];
         if (!handler) return;
-        handler(req, mockResponse, () => {});
+        return handler(req, mockResponse, () => {});
       };
     });
     it('should be registered', async () => {
@@ -229,9 +262,6 @@ describe('API Routes', () => {
       );
     });
     it('should succeed when branchName and user is provided', async () => {
-      jest.spyOn(StateService, 'removePriorityBranch');
-      expect(mockRunner.onStatusUpdate).not.toHaveBeenCalled();
-      expect(mockResponse.sendStatus).not.toHaveBeenCalled();
       await removePriorityBranchHandler(
         {
           body: {
@@ -246,6 +276,21 @@ describe('API Routes', () => {
         expect.objectContaining({ message: 'test/test-branch successfully removed.' }),
       );
       expect(mockResponse.status).toHaveBeenCalledWith(200);
+    });
+    it('should return 500 on unexpected failure', async () => {
+      (StateService.removePriorityBranch as jest.Mock).mockResolvedValueOnce(false);
+      await removePriorityBranchHandler(
+        {
+          body: {
+            branchName: 'test/test-branch',
+          },
+          user: { aaid: 'mock-user-aaid' },
+        },
+        mockExpress.response,
+        () => {},
+      );
+      expect(StateService.removePriorityBranch).toHaveBeenCalledWith('test/test-branch');
+      expect(mockResponse.sendStatus).toHaveBeenCalledWith(500);
     });
   });
   // todo: add tests for other routes


### PR DESCRIPTION
I've been running into flakey cypress tests when trying to integrate the changes from https://github.com/atlassian/landkid/pull/210 into atlassian-frontend.

Some of the flakiness relates to server state not being reset in between tests/test suites/test executions - especially if there is a failure.

I've made a couple of changes to help with this:

* New route to delete all priority branches
* Update to the recently added routes to return error status codes on failure. I noticed these were not awaiting the DB calls and always returning success.

I plan to update the cypress test code to these routes to reset server state where required.