### PR TITLE
Add impact field to LandRequest

### DIFF
--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -259,6 +259,27 @@ export class BitbucketAPI {
     return priority;
   };
 
+  getPRImpact = async (commit: string): Promise<number> => {
+    const endpoint = `${this.baseUrl}/commit/${commit}/statuses`;
+    const { data } = await axios.get<{ values: BB.BuildPriorityImpact[] }>(
+      endpoint,
+      await bitbucketAuthenticator.getAuthConfig(fromMethodAndUrl('get', endpoint)),
+    );
+
+    const allBuildStatuses = data.values;
+    const impact =
+      allBuildStatuses.find((buildStatus) => buildStatus.name === 'landkid-impact')?.description ||
+      '0';
+
+    Logger.info('PR impact', {
+      namespace: 'bitbucket:api:getPRImpact',
+      commit,
+      impact,
+    });
+
+    return parseInt(impact);
+  };
+
   getUser = async (aaid: string): Promise<ISessionUser> => {
     const endpoint = `https://api.bitbucket.org/2.0/users/${aaid}`;
     const resp = await axios.get(

--- a/src/bitbucket/__mocks__/BitbucketAPI.ts
+++ b/src/bitbucket/__mocks__/BitbucketAPI.ts
@@ -10,6 +10,7 @@ export const BitbucketAPI = jest.fn().mockImplementation((...args) => {
   api.pullRequestHasConflicts = jest.fn();
   api.getPullRequestBuildStatuses = jest.fn();
   api.getPullRequestPriority = jest.fn();
+  api.getPRImpact = jest.fn();
   api.getUser = jest.fn();
   api.getRepository = jest.fn();
 

--- a/src/bitbucket/__tests__/BitbucketAPI.test.ts
+++ b/src/bitbucket/__tests__/BitbucketAPI.test.ts
@@ -211,4 +211,26 @@ describe('getPullRequestPriority', () => {
 
     expect(await bitbucketAPI.getPullRequestPriority('commit-foo')).toBe('LOW');
   });
+  test('when build status includes "landkid-impact" then should return impact ', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        values: [
+          {
+            name: 'landkid-impact',
+            description: '10',
+          },
+        ],
+      },
+    });
+
+    expect(await bitbucketAPI.getPRImpact('commit-foo')).toBe(10);
+  });
+  test('when no "landkid-impact" build status is sent the default impact value should be sent', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        values: [],
+      },
+    });
+    expect(await bitbucketAPI.getPRImpact('commit-foo')).toBe(0);
+  });
 });

--- a/src/bitbucket/types.d.ts
+++ b/src/bitbucket/types.d.ts
@@ -144,6 +144,11 @@ declare namespace BB {
     description: PRPriority;
   };
 
+  type BuildPriorityImpact = {
+    name: string;
+    description: string;
+  };
+
   type BuildStatus = {
     name: string;
     state: BuildState;

--- a/src/db/__mocks__/index.ts
+++ b/src/db/__mocks__/index.ts
@@ -15,6 +15,7 @@ export const LandRequest = jest.fn((props) => {
     incrementPriority: jest.fn(),
     decrementPriority: jest.fn(),
     getQueuedDate: jest.fn(() => new Date('2020-01-01')),
+    updateImpact: jest.fn(),
   });
   return req;
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -80,6 +80,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   @Column(Sequelize.INTEGER)
   priority: number;
 
+  // Impact is used by the speculationEngine
   @AllowNull(true)
   @Default(0)
   @Column(Sequelize.INTEGER)

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -81,6 +81,11 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   priority: number;
 
   @AllowNull(true)
+  @Default(0)
+  @Column(Sequelize.INTEGER)
+  impact: number;
+
+  @AllowNull(true)
   @Column(
     Sequelize.ENUM({
       values: ['squash', 'merge-commit'],
@@ -217,6 +222,11 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
       order: [['date', 'ASC']],
     });
     return status ? status.date : null;
+  };
+
+  updateImpact = (impact: number) => {
+    this.impact = impact;
+    return this.save();
   };
 }
 

--- a/src/db/migrations/09__impactColumn.ts
+++ b/src/db/migrations/09__impactColumn.ts
@@ -1,0 +1,18 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  up: function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.describeTable('LandRequest').then((table: any) => {
+      if (table.impact) return;
+      return query.addColumn('LandRequest', 'impact', {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        defaultValue: 0,
+      });
+    });
+  },
+  // VIOLATES FOREIGN KEY CONSTRAINT
+  down: function () {
+    throw new Error('NO DROP FUNCTION FOR THIS MIGRATION');
+  },
+};

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -541,6 +541,9 @@ export class Runner {
     const user = await this.client.getUser(request.triggererAaid);
     await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
 
+    const impact = await this.client.bitbucket.getPRImpact(request.forCommit);
+    request.updateImpact(impact);
+
     return true;
   };
 

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -541,6 +541,7 @@ export class Runner {
     const user = await this.client.getUser(request.triggererAaid);
     await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
 
+    // TODO: add condition to check if the speculation engine is enabled from the admin settings
     const impact = await this.client.bitbucket.getPRImpact(request.forCommit);
     request.updateImpact(impact);
 

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -196,15 +196,19 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
 
       const priority = await client.bitbucket.getPullRequestPriority(commit);
 
-      if (priority === 'HIGH' && request) {
-        await request.incrementPriority();
-        Logger.info('Pull request priority increased', {
-          namespace: 'routes:bitbucket:proxy:land',
-          pullRequestId: prId,
-          landRequest,
-        });
-      }
+      if (request) {
+        if (priority === 'HIGH') {
+          await request.incrementPriority();
+          Logger.info('Pull request priority increased', {
+            namespace: 'routes:bitbucket:proxy:land',
+            pullRequestId: prId,
+            landRequest,
+          });
+        }
 
+        const impact = await client.bitbucket.getPRImpact(commit);
+        request.updateImpact(impact);
+      }
       res.sendStatus(200);
       runner.next();
     }),

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -205,7 +205,7 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
             landRequest,
           });
         }
-
+        // TODO: add condition to check if the speculation engine is enabled from the admin settings
         const impact = await client.bitbucket.getPRImpact(commit);
         request.updateImpact(impact);
       }

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -331,6 +331,13 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
             </StatusItem>
           </div>
         ) : null}
+        {status.request.impact ? (
+          <div className="queue-item__status-line">
+            <StatusItem id="impact" title="Impact:">
+              {status.request.impact}
+            </StatusItem>
+          </div>
+        ) : null}
         {status.state === 'queued' ? (
           <div className="queue-item__status-line">
             <StatusItem title="Admin Controls:">

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -27,6 +27,7 @@ declare interface ILandRequest {
   pullRequest: IPullRequest;
   dependsOn: string | null;
   priority: number | null;
+  impact: number | null;
 }
 
 declare interface IPullRequest {


### PR DESCRIPTION
- Add impact field to LandRequest
![image](https://user-images.githubusercontent.com/19305535/223587425-5dfeca13-731b-492f-b389-6d29b89da9b1.png)

- Add new migration script to update new column
- Update unit tests
- Add impact field to QueueItem UI
![image](https://user-images.githubusercontent.com/19305535/223574028-b49585ae-3362-4790-989b-22bb9e29a653.png)



![image](https://user-images.githubusercontent.com/19305535/223574107-b88b313d-c4f8-4b15-b1b6-69f7f9aaca4f.png)

- Used BBC APIs to create a build status commit with my own test repository 
e.g. used curl to send the API request:  `curl -u 'wfyzheng:<auth token>' --request POST --url "https://api.bitbucket.org/2.0/repositories/wfyzheng/test/commit/d3ffb5f5fe59dd62a0ee1278a0367079ad4c4c05/statuses/build" -H 'Content-Type: application/json' -d '{"name": "landkid-impact", "key": "landkid-impact","state": "SUCCESSFUL", "description": "42", "url": "www.google.com"}'`
![image](https://user-images.githubusercontent.com/19305535/223584846-6b35a4de-0848-45cd-b12f-0a66cb81864b.png)

