### PR TITLE
Integrate speculation engine with impact

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -76,6 +76,11 @@ module.exports = {
       ],
     },
   },
+  /**
+   * Speculation engine re-orders top n PRs where n is the available free slots based on the impact of the PRs. The lower impact PRs are given preference.
+   * Impact meta data is processed and send to landkid by the consuming repo using build statuses.
+   */
+  speculationEngineEnabled: false,
   eventListeners: [
     {
       event: 'PULL_REQUEST.MERGE.SUCCESS',

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -440,6 +440,12 @@ export class AdminSettings extends Model<AdminSettings> implements IAdminSetting
   @Default(false)
   @Column(Sequelize.BOOLEAN)
   readonly mergeBlockingEnabled: boolean;
+
+  // // adding coulmn is causing an issue, db upgrade is required.
+  // @AllowNull(false)
+  // @Default(false)
+  // @Column(Sequelize.BOOLEAN)
+  // readonly speculationEngineEnabled: boolean;
 }
 
 export const initializeSequelize = async () => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -441,11 +441,11 @@ export class AdminSettings extends Model<AdminSettings> implements IAdminSetting
   @Column(Sequelize.BOOLEAN)
   readonly mergeBlockingEnabled: boolean;
 
-  // // adding coulmn is causing an issue, db upgrade is required.
-  // @AllowNull(false)
-  // @Default(false)
-  // @Column(Sequelize.BOOLEAN)
-  // readonly speculationEngineEnabled: boolean;
+  // adding coulmn is causing an issue, db upgrade is required.
+  @AllowNull(false)
+  @Default(false)
+  @Column(Sequelize.BOOLEAN)
+  readonly speculationEngineEnabled: boolean;
 }
 
 export const initializeSequelize = async () => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -441,7 +441,7 @@ export class AdminSettings extends Model<AdminSettings> implements IAdminSetting
   @Column(Sequelize.BOOLEAN)
   readonly mergeBlockingEnabled: boolean;
 
-  // adding coulmn is causing an issue, db upgrade is required.
+  /** Live feature toggling of config.speculationEngineEnabled. Must be first enabled in config to be enabled here */
   @AllowNull(false)
   @Default(false)
   @Column(Sequelize.BOOLEAN)

--- a/src/db/migrations/10__speculationEngineAdminSettings.ts
+++ b/src/db/migrations/10__speculationEngineAdminSettings.ts
@@ -1,0 +1,17 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  async up(queryInterface: QueryInterface, Sequelize: DataTypes) {
+    const table: any = await queryInterface.describeTable('AdminSettings');
+    if (table.speculationEngineEnabled) return;
+    return queryInterface.addColumn('AdminSettings', 'speculationEngineEnabled', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
+  },
+
+  async down() {
+    throw new Error('NO DROP FUNCTION FOR THIS MIGRATION');
+  },
+};

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -22,12 +22,14 @@ export class LandRequestQueue {
 
   // returns the list of queued, running, awaiting-merge, and merging items as these are the actual "queue" per se
   // all the status' we display on the frontend
-  public getQueue = async () => {
+  public getQueue = async (
+    state: IStatusState[] = ['queued', 'running', 'awaiting-merge', 'merging'],
+  ) => {
     const queue = await LandRequestStatus.findAll<LandRequestStatus>({
       where: {
         isLatest: true,
         state: {
-          $in: ['queued', 'running', 'awaiting-merge', 'merging'],
+          $in: state,
         },
       },
       order: [
@@ -46,12 +48,12 @@ export class LandRequestQueue {
 
   // returns builds that are running, awaiting-merge, or merging, used to find the dependencies of a request
   // that is about to move to running state
-  public getRunning = async () => {
+  public getRunning = async (state: IStatusState[] = ['running', 'awaiting-merge', 'merging']) => {
     return LandRequestStatus.findAll<LandRequestStatus>({
       where: {
         isLatest: true,
         state: {
-          $in: ['running', 'awaiting-merge', 'merging'],
+          $in: state,
         },
       },
       order: [['date', 'ASC']],

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -12,6 +12,7 @@ import { eventEmitter } from './Events';
 import { BitbucketAPI } from '../bitbucket/BitbucketAPI';
 import { StateService } from './StateService';
 import { validatePriorityBranch } from './utils/helper-functions';
+import { SepculationEngine } from './SpeculationEngine';
 
 // const MAX_WAITING_TIME_FOR_PR_MS = 2 * 24 * 60 * 60 * 1000; // 2 days - max time build can "land-when able"
 
@@ -50,12 +51,12 @@ export class Runner {
     }, 10 * 60 * 1000);
   }
 
-  getQueue = async () => {
-    return this.queue.getQueue();
+  getQueue = async (states?: IStatusState[]) => {
+    return this.queue.getQueue(states);
   };
 
-  getRunning = async () => {
-    return this.queue.getRunning();
+  getRunning = async (states?: IStatusState[]) => {
+    return this.queue.getRunning(states);
   };
 
   getWaitingAndQueued = async () => {
@@ -68,6 +69,12 @@ export class Runner {
     const maxConcurrentBuilds = await StateService.getMaxConcurrentBuilds();
     const running = processingLandRequestStatuses.filter(({ state }) => state === 'running');
     return running.length >= maxConcurrentBuilds;
+  };
+
+  getAvailableSlots = async (processingLandRequestStatuses: LandRequestStatus[]) => {
+    const maxConcurrentBuilds = await StateService.getMaxConcurrentBuilds();
+    const running = processingLandRequestStatuses.filter(({ state }) => state === 'running');
+    return maxConcurrentBuilds - running.length;
   };
 
   moveFromQueueToRunning = async (landRequestStatus: LandRequestStatus, lockId: Date) => {
@@ -126,6 +133,16 @@ export class Runner {
         errors: isAllowedToLand.errors,
       });
       return landRequest.setStatus('fail', 'Unable to land due to failed land checks');
+    }
+
+    if (
+      await SepculationEngine.reOrderRequest(
+        runningTargetingSameBranch,
+        await this.getQueue(['queued']),
+        landRequestStatus,
+      )
+    ) {
+      return false;
     }
 
     const runningExceptSelf = runningTargetingSameBranch.filter(

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -12,7 +12,7 @@ import { eventEmitter } from './Events';
 import { BitbucketAPI } from '../bitbucket/BitbucketAPI';
 import { StateService } from './StateService';
 import { validatePriorityBranch } from './utils/helper-functions';
-import { SepculationEngine } from './SpeculationEngine';
+import { SpeculationEngine } from './SpeculationEngine';
 
 // const MAX_WAITING_TIME_FOR_PR_MS = 2 * 24 * 60 * 60 * 1000; // 2 days - max time build can "land-when able"
 
@@ -130,7 +130,7 @@ export class Runner {
     }
 
     if (
-      await SepculationEngine.reOrderRequest(
+      await SpeculationEngine.reOrderRequest(
         runningTargetingSameBranch,
         await this.getQueue(['queued']),
         landRequestStatus,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -71,12 +71,6 @@ export class Runner {
     return running.length >= maxConcurrentBuilds;
   };
 
-  getAvailableSlots = async (processingLandRequestStatuses: LandRequestStatus[]) => {
-    const maxConcurrentBuilds = await StateService.getMaxConcurrentBuilds();
-    const running = processingLandRequestStatuses.filter(({ state }) => state === 'running');
-    return maxConcurrentBuilds - running.length;
-  };
-
   moveFromQueueToRunning = async (landRequestStatus: LandRequestStatus, lockId: Date) => {
     if (await StateService.getPauseState()) return;
     const landRequest = landRequestStatus.request;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -552,9 +552,11 @@ export class Runner {
     const user = await this.client.getUser(request.triggererAaid);
     await request.setStatus('queued', `Queued by ${user.displayName || user.aaid}`);
 
-    // TODO: add condition to check if the speculation engine is enabled from the admin settings
-    const impact = await this.client.bitbucket.getPRImpact(request.forCommit);
-    request.updateImpact(impact);
+    const { speculationEngineEnabled } = await StateService.getAdminSettings();
+    if (speculationEngineEnabled) {
+      const impact = await this.client.bitbucket.getPRImpact(request.forCommit);
+      request.updateImpact(impact);
+    }
 
     return true;
   };

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -2,7 +2,7 @@ import { LandRequest, LandRequestStatus } from '../db';
 import { Logger } from './Logger';
 import { StateService } from './StateService';
 
-export class SepculationEngine {
+export class SpeculationEngine {
   constructor() {}
 
   static async getAvailableSlots(running: LandRequestStatus[]): Promise<number> {

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -17,9 +17,9 @@ export class SepculationEngine {
   static async getImpact(queued: LandRequestStatus[], position: number) {
     const currentRequestStatus = queued[position];
     const nextRequestStatus = queued[position + 1];
-    // TODO: Replace with impact from land request.
-    const currentImpact = Math.round(Math.random() * 100);
-    const nextImpact = Math.round(Math.random() * 100);
+
+    const currentImpact = currentRequestStatus.request.impact;
+    const nextImpact = nextRequestStatus.request.impact;
 
     Logger.info('Impact retrieved:', {
       namespace: 'lib:speculationEngine:getImpact',

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -37,7 +37,7 @@ export class SepculationEngine {
    * Attempts to re-order if
    *      1. speculationEngineEnabled feature is enabled
    *      2. available free slots are atleast 2
-   *      3. Position of current requests in the queue compared to numner of slots.
+   *      3. Position of current requests in the queue compared to number of slots.
    *         for example if 2 slots are available consider re-ordering 1st request from the queue
    *                     if 3 slots are available consider re-ordering 1st and 2nd request from the queue
    *      4. Size of queue is more than 1

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -76,7 +76,9 @@ export class SepculationEngine {
     });
 
     if (availableSlots < 2 || queued.length < 2 || position >= availableSlots - 1) {
-      logMessage('Not attempting to re-order the PR');
+      logMessage(
+        'Skipping re-order request. Speculation engine conditions to re-order PRs are not met.',
+      );
       return false;
     }
 

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -1,0 +1,88 @@
+import { LandRequest, LandRequestStatus } from '../db';
+import { Logger } from './Logger';
+import { StateService } from './StateService';
+
+export class SepculationEngine {
+  constructor() {}
+
+  static async getAvailableSlots(running: LandRequestStatus[]): Promise<number> {
+    const maxConcurrentBuilds = await StateService.getMaxConcurrentBuilds();
+    return maxConcurrentBuilds - running.filter(({ state }) => state === 'running').length;
+  }
+
+  static async positionInQueue(queued: LandRequestStatus[], landRequestStatus: LandRequestStatus) {
+    return queued.findIndex(({ id }) => id === landRequestStatus.id);
+  }
+
+  static async getImpact(queued: LandRequestStatus[], position: number) {
+    const currentRequestStatus = queued[position];
+    const nextRequestStatus = queued[position + 1];
+
+    Logger.info('Calculating impact of', {
+      namespace: 'lib:speculationEngine:getImpact',
+      currentRequestStatus,
+      nextRequestStatus,
+    });
+
+    return {
+      currentImpact: Math.round(Math.random() * 100),
+      nextImpact: Math.round(Math.random() * 100),
+    };
+  }
+
+  /**
+   *
+   * Attempts to re-order if
+   *      1. speculationEngineEnabled feature is enabled
+   *      2. available free slots are atleast 2
+   *      3. Position of current requests in the queue compared to numner of slots.
+   *         for example if 2 slots are available consider re-ordering 1st request from the queue
+   *                     if 3 slots are available consider re-ordering 1st and 2nd request from the queue
+   *      4. Size of queue is more than 1
+   *      5. Impact of the current request
+   *
+   * @param running
+   * @param queued
+   * @param currentlandRequestStatus
+   * @returns true if requests needs to be re-ordered.
+   *
+   */
+  static async reOrderRequest(
+    running: LandRequestStatus[],
+    queued: LandRequestStatus[],
+    currentlandRequestStatus: LandRequestStatus,
+  ): Promise<boolean> {
+    const { speculationEngineEnabled } = await StateService.getAdminSettings();
+    if (!speculationEngineEnabled) {
+      return false;
+    }
+
+    const availableSlots = await this.getAvailableSlots(running);
+    const landRequest: LandRequest = currentlandRequestStatus.request;
+    const position = await this.positionInQueue(queued, currentlandRequestStatus);
+    if (availableSlots < 2 || position == availableSlots - 1) {
+      return false;
+    }
+
+    Logger.info('Attempting to re-order PR based on impact', {
+      namespace: 'lib:speculationEngine:reOrderRequest',
+      landRequestId: landRequest.id,
+      pullRequestId: landRequest.pullRequestId,
+    });
+
+    const { currentImpact, nextImpact } = await this.getImpact(queued, position);
+    if (currentImpact > nextImpact) {
+      // re-order as current impact is greater than next impact
+      Logger.info('PR re-ordered based on speculation', {
+        namespace: 'lib:speculationEngine:reOrderRequest',
+        landRequestId: landRequest.id,
+        pullRequestId: landRequest.pullRequestId,
+        currentImpact,
+        nextImpact,
+      });
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -19,12 +19,13 @@ export class SpeculationEngine {
     const queuedRequestsLength = position + availableSlots - 1;
     const nextQueuedRequestStatus = queued.slice(position, queuedRequestsLength + 1);
 
-    const queuedRequestImpacts = nextQueuedRequestStatus.map((requestStatus) => {
-      return requestStatus.request.impact;
-    });
+    const queuedRequestImpacts = nextQueuedRequestStatus.map(
+      (requestStatus) => requestStatus.request.impact,
+    );
 
     Logger.info('Impact retrieved for next queued requests:', {
       namespace: 'lib:speculationEngine:getImpact',
+      pullRequestId: queued[position].request.pullRequestId,
       impact: queuedRequestImpacts,
     });
 

--- a/src/lib/SpeculationEngine.ts
+++ b/src/lib/SpeculationEngine.ts
@@ -17,10 +17,11 @@ export class SepculationEngine {
   static async getImpact(queued: LandRequestStatus[], position: number) {
     const currentRequestStatus = queued[position];
     const nextRequestStatus = queued[position + 1];
+    // TODO: Replace with impact from land request.
     const currentImpact = Math.round(Math.random() * 100);
     const nextImpact = Math.round(Math.random() * 100);
 
-    Logger.info('Calculating impact of', {
+    Logger.info('Impact retrieved:', {
       namespace: 'lib:speculationEngine:getImpact',
       pullRequestId: currentRequestStatus.request.pullRequestId,
       nextPullRequestId: nextRequestStatus.request.pullRequestId,
@@ -74,7 +75,7 @@ export class SepculationEngine {
       queued: queued.map(({ request }) => request.pullRequestId),
     });
 
-    if (availableSlots < 2 || position >= availableSlots - 1 || queued.length < 2) {
+    if (availableSlots < 2 || queued.length < 2 || position >= availableSlots - 1) {
       logMessage('Not attempting to re-order the PR');
       return false;
     }

--- a/src/lib/StateService.ts
+++ b/src/lib/StateService.ts
@@ -183,6 +183,7 @@ export class StateService {
 
   static async getAdminSettings(): Promise<IAdminSettings> {
     const defaultMergeBlockingEnabled = !!config.mergeSettings?.mergeBlocking?.enabled;
+    const defaultSpeculationEngineEnabled = !!config.speculationEngineEnabled;
     const settings = await AdminSettings.findOne<AdminSettings>({
       order: [['date', 'DESC']],
     });
@@ -190,13 +191,15 @@ export class StateService {
     if (!settings) {
       return {
         mergeBlockingEnabled: defaultMergeBlockingEnabled,
-        speculationEngineEnabled: true,
+        speculationEngineEnabled: defaultSpeculationEngineEnabled,
       };
     }
 
     return {
       mergeBlockingEnabled: defaultMergeBlockingEnabled ? settings.mergeBlockingEnabled : false,
-      speculationEngineEnabled: true,
+      speculationEngineEnabled: defaultSpeculationEngineEnabled
+        ? settings.speculationEngineEnabled
+        : false,
     };
   }
 
@@ -208,6 +211,7 @@ export class StateService {
       await AdminSettings.create<AdminSettings>({
         adminAaid: user.aaid,
         mergeBlockingEnabled: settings.mergeBlockingEnabled,
+        speculationEngineEnabled: settings.speculationEngineEnabled,
       });
       return true;
     } catch (error) {
@@ -246,7 +250,10 @@ export class StateService {
       maxConcurrentBuilds,
       priorityBranchList,
       adminSettings,
-      config: { mergeSettings: config.mergeSettings },
+      config: {
+        mergeSettings: config.mergeSettings,
+        speculationEngineEnabled: config.speculationEngineEnabled,
+      },
     };
   }
 }

--- a/src/lib/StateService.ts
+++ b/src/lib/StateService.ts
@@ -190,11 +190,13 @@ export class StateService {
     if (!settings) {
       return {
         mergeBlockingEnabled: defaultMergeBlockingEnabled,
+        speculationEngineEnabled: true,
       };
     }
 
     return {
       mergeBlockingEnabled: defaultMergeBlockingEnabled ? settings.mergeBlockingEnabled : false,
+      speculationEngineEnabled: true,
     };
   }
 
@@ -227,14 +229,14 @@ export class StateService {
       bannerMessageState,
       maxConcurrentBuilds,
       priorityBranchList,
-      adminSettings,
+      // adminSettings,
     ] = await Promise.all([
       this.getDatesSinceLastFailures(),
       this.getPauseState(),
       this.getBannerMessageState(),
       this.getMaxConcurrentBuilds(),
       this.getPriorityBranches(),
-      this.getAdminSettings(),
+      // this.getAdminSettings(),
     ]);
 
     return {
@@ -243,7 +245,7 @@ export class StateService {
       bannerMessageState,
       maxConcurrentBuilds,
       priorityBranchList,
-      adminSettings,
+      adminSettings: {} as any,
       config: { mergeSettings: config.mergeSettings },
     };
   }

--- a/src/lib/StateService.ts
+++ b/src/lib/StateService.ts
@@ -229,14 +229,14 @@ export class StateService {
       bannerMessageState,
       maxConcurrentBuilds,
       priorityBranchList,
-      // adminSettings,
+      adminSettings,
     ] = await Promise.all([
       this.getDatesSinceLastFailures(),
       this.getPauseState(),
       this.getBannerMessageState(),
       this.getMaxConcurrentBuilds(),
       this.getPriorityBranches(),
-      // this.getAdminSettings(),
+      this.getAdminSettings(),
     ]);
 
     return {
@@ -245,7 +245,7 @@ export class StateService {
       bannerMessageState,
       maxConcurrentBuilds,
       priorityBranchList,
-      adminSettings: {} as any,
+      adminSettings,
       config: { mergeSettings: config.mergeSettings },
     };
   }

--- a/src/lib/__mocks__/Config.ts
+++ b/src/lib/__mocks__/Config.ts
@@ -36,4 +36,5 @@ export const config: Config = {
   maxConcurrentBuilds: 2,
   permissionsMessage: '',
   mergeSettings: {},
+  speculationEngineEnabled: false,
 };

--- a/src/lib/__mocks__/StateService.ts
+++ b/src/lib/__mocks__/StateService.ts
@@ -14,6 +14,10 @@ StateService.getPriorityBranches.mockResolvedValue([
     date: '2023-01-25T04:28:07.817Z',
   },
 ]);
+StateService.getAdminSettings.mockResolvedValue({
+  speculationEngineEnabled: false,
+  mergeBlockingEnabled: false,
+});
 StateService.getState.mockResolvedValue({
   bannerMessageState: null,
   pauseState: null,

--- a/src/lib/__tests__/Runner.test.ts
+++ b/src/lib/__tests__/Runner.test.ts
@@ -929,7 +929,7 @@ describe('Runner', () => {
       });
       jest
         .spyOn(StateService, 'getAdminSettings')
-        .mockResolvedValueOnce({ mergeBlockingEnabled: true });
+        .mockResolvedValueOnce({ mergeBlockingEnabled: true } as any);
       jest.spyOn(mockClient, 'isBlockingBuildRunning').mockResolvedValueOnce({ running: true });
 
       const response = await runner.moveFromAwaitingMerge(status, new Date('2020-01-01'), []);
@@ -963,7 +963,7 @@ describe('Runner', () => {
       });
       jest
         .spyOn(StateService, 'getAdminSettings')
-        .mockResolvedValueOnce({ mergeBlockingEnabled: true });
+        .mockResolvedValueOnce({ mergeBlockingEnabled: true } as any);
       jest.spyOn(mockClient, 'isBlockingBuildRunning').mockResolvedValueOnce({ running: false });
       jest.spyOn(mockClient, 'mergePullRequest').mockResolvedValueOnce({
         status: 'success',

--- a/src/lib/__tests__/SepculationEngine.test.ts
+++ b/src/lib/__tests__/SepculationEngine.test.ts
@@ -33,6 +33,7 @@ describe('SepculationEngine', () => {
           created: new Date(120),
           forCommit: 'abc',
           id: '0',
+          impact: 100,
           triggererAaid: '123',
           pullRequestId: 0,
           pullRequest,
@@ -48,6 +49,7 @@ describe('SepculationEngine', () => {
           created: new Date(120),
           forCommit: 'abc',
           id: '1',
+          impact: 50,
           triggererAaid: '123',
           pullRequestId: 1,
           pullRequest,
@@ -109,9 +111,8 @@ describe('SepculationEngine', () => {
   test('getImpact > should return impact', async () => {
     const impact = await SepculationEngine.getImpact(mockQueued, 0);
 
-    // todo update after actual implementation of impact logic
-    expect(typeof impact.currentImpact).toBe('number');
-    expect(typeof impact.nextImpact).toBe('number');
+    expect(impact.currentImpact).toBe(100);
+    expect(impact.nextImpact).toBe(50);
   });
 
   describe('reOrderRequest', () => {

--- a/src/lib/__tests__/SepculationEngine.test.ts
+++ b/src/lib/__tests__/SepculationEngine.test.ts
@@ -1,0 +1,14 @@
+describe('SepculationEngine', () => {
+  test('getImpact > should return impact', async () => {});
+  test('positionInQueue > should return position in queue', async () => {});
+  test('getAvailableSlots > should return availabled free slots', async () => {});
+
+  describe('reOrderRequest', () => {
+    test('should return false when the feature is turned off', async () => {});
+    test('should return false when number of free slots are less than 2', async () => {});
+    test('should return false when number of free slots are 2 and current request is 2nd in the queue', async () => {});
+    test('should return false when number of free slots are 3 and current request is 3rd in the queue', async () => {});
+    test('should return false when number of free slots are 2, current request is 1st in the queue and current request`s impact is less than next', async () => {});
+    test('should return true when number of free slots are 2, current request is 1st in the queue and current request`s impact is greater than next', async () => {});
+  });
+});

--- a/src/lib/__tests__/SepculationEngine.test.ts
+++ b/src/lib/__tests__/SepculationEngine.test.ts
@@ -1,11 +1,11 @@
 import { LandRequest, LandRequestStatus, PullRequest } from '../../db';
-import { SepculationEngine } from '../SpeculationEngine';
+import { SpeculationEngine } from '../SpeculationEngine';
 import { StateService } from '../StateService';
 
 jest.mock('../StateService');
 jest.mock('../../db/index');
 
-describe('SepculationEngine', () => {
+describe('SpeculationEngine', () => {
   let mockQueued: LandRequestStatus[] = [];
   let mockRunning: LandRequestStatus[] = [];
   let mockPullRequest: BB.PullRequest;
@@ -99,17 +99,17 @@ describe('SepculationEngine', () => {
 
   test('getAvailableSlots > should return availabled free slots', async () => {
     jest.spyOn(StateService, 'getMaxConcurrentBuilds').mockResolvedValue(3);
-    expect(await SepculationEngine.getAvailableSlots(mockRunning)).toBe(1);
-    expect(await SepculationEngine.getAvailableSlots([])).toBe(3);
+    expect(await SpeculationEngine.getAvailableSlots(mockRunning)).toBe(1);
+    expect(await SpeculationEngine.getAvailableSlots([])).toBe(3);
   });
 
   test('positionInQueue > should return position in queue', async () => {
-    expect(await SepculationEngine.positionInQueue(mockQueued, mockQueued[1])).toBe(1);
-    expect(await SepculationEngine.positionInQueue(mockQueued, mockQueued[0])).toBe(0);
+    expect(await SpeculationEngine.positionInQueue(mockQueued, mockQueued[1])).toBe(1);
+    expect(await SpeculationEngine.positionInQueue(mockQueued, mockQueued[0])).toBe(0);
   });
 
   test('getImpact > should return impact', async () => {
-    const impact = await SepculationEngine.getImpact(mockQueued, 0);
+    const impact = await SpeculationEngine.getImpact(mockQueued, 0);
 
     expect(impact.currentImpact).toBe(100);
     expect(impact.nextImpact).toBe(50);
@@ -120,17 +120,17 @@ describe('SepculationEngine', () => {
       jest
         .spyOn(StateService, 'getAdminSettings')
         .mockResolvedValueOnce({ speculationEngineEnabled: false } as any);
-      jest.spyOn(SepculationEngine, 'getImpact').mockResolvedValueOnce({
+      jest.spyOn(SpeculationEngine, 'getImpact').mockResolvedValueOnce({
         currentImpact: 10,
         nextImpact: 100,
       });
-      const reOrder = await SepculationEngine.reOrderRequest(
+      const reOrder = await SpeculationEngine.reOrderRequest(
         mockRunning,
         mockQueued,
         mockQueued[0],
       );
 
-      expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+      expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
       expect(reOrder).toBe(false);
     });
 
@@ -140,7 +140,7 @@ describe('SepculationEngine', () => {
           speculationEngineEnabled: true,
         } as any);
         jest.spyOn(StateService, 'getMaxConcurrentBuilds').mockResolvedValueOnce(3);
-        jest.spyOn(SepculationEngine, 'getImpact').mockResolvedValueOnce({
+        jest.spyOn(SpeculationEngine, 'getImpact').mockResolvedValueOnce({
           currentImpact: 10,
           nextImpact: 100,
         });
@@ -149,20 +149,20 @@ describe('SepculationEngine', () => {
         // 1 free slots, getMaxConcurrentBuilds is 3 and running is 2
         // queued length is 2
         // position in queue is 0
-        let reOrder = await SepculationEngine.reOrderRequest(
+        let reOrder = await SpeculationEngine.reOrderRequest(
           mockRunning,
           mockQueued,
           mockQueued[0],
         );
-        expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+        expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
         expect(reOrder).toBe(false);
 
         // 0 free slots, getMaxConcurrentBuilds is 2 and running is 2
         // queued length is 2
         // position in queue is 0
         jest.spyOn(StateService, 'getMaxConcurrentBuilds').mockResolvedValueOnce(2);
-        reOrder = await SepculationEngine.reOrderRequest(mockRunning, mockQueued, mockQueued[0]);
-        expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+        reOrder = await SpeculationEngine.reOrderRequest(mockRunning, mockQueued, mockQueued[0]);
+        expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
         expect(reOrder).toBe(false);
       });
 
@@ -170,12 +170,12 @@ describe('SepculationEngine', () => {
         // 2 free slots, getMaxConcurrentBuilds is 3 and running is 1
         // queued length is 1
         // position in queue is 0
-        const reOrder = await SepculationEngine.reOrderRequest(
+        const reOrder = await SpeculationEngine.reOrderRequest(
           [mockRunning[0]],
           [mockQueued[0]],
           mockQueued[0],
         );
-        expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+        expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
         expect(reOrder).toBe(false);
       });
 
@@ -183,12 +183,12 @@ describe('SepculationEngine', () => {
         // 2 free slots, getMaxConcurrentBuilds is 3 and running is 1
         // queued length is 2
         // position in queue is 1 ie 2nd in the queue
-        const reOrder = await SepculationEngine.reOrderRequest(
+        const reOrder = await SpeculationEngine.reOrderRequest(
           [mockRunning[0]],
           mockQueued,
           mockQueued[1],
         );
-        expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+        expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
         expect(reOrder).toBe(false);
       });
 
@@ -202,12 +202,12 @@ describe('SepculationEngine', () => {
           request: new LandRequest({ pullRequestId: 3 }),
         });
 
-        const reOrder = await SepculationEngine.reOrderRequest(
+        const reOrder = await SpeculationEngine.reOrderRequest(
           [],
           [...mockQueued, queuedRequestStatus],
           queuedRequestStatus,
         );
-        expect(SepculationEngine.getImpact).not.toHaveBeenCalled();
+        expect(SpeculationEngine.getImpact).not.toHaveBeenCalled();
         expect(reOrder).toBe(false);
       });
 
@@ -216,32 +216,32 @@ describe('SepculationEngine', () => {
         // queued length is 2
         // position in queue is 0 ie 1st in the queue
 
-        const reOrder = await SepculationEngine.reOrderRequest(
+        const reOrder = await SpeculationEngine.reOrderRequest(
           [mockRunning[0]],
           mockQueued,
           mockQueued[0],
         );
 
-        expect(SepculationEngine.getImpact).toHaveBeenCalledWith(mockQueued, 0);
+        expect(SpeculationEngine.getImpact).toHaveBeenCalledWith(mockQueued, 0);
         expect(reOrder).toBe(false);
       });
       test('should re-order when number of free slots are 2, current request is 1st in the queue and current request`s impact is greater than next', async () => {
         // 2 free slots, getMaxConcurrentBuilds is 3 and running is 1
         // queued length is 2
         // position in queue is 0 ie 1st in the queue
-        (SepculationEngine.getImpact as jest.Mock).mockReset();
-        jest.spyOn(SepculationEngine, 'getImpact').mockResolvedValueOnce({
+        (SpeculationEngine.getImpact as jest.Mock).mockReset();
+        jest.spyOn(SpeculationEngine, 'getImpact').mockResolvedValueOnce({
           currentImpact: 200,
           nextImpact: 100,
         });
 
-        const reOrder = await SepculationEngine.reOrderRequest(
+        const reOrder = await SpeculationEngine.reOrderRequest(
           [mockRunning[0]],
           mockQueued,
           mockQueued[0],
         );
 
-        expect(SepculationEngine.getImpact).toHaveBeenCalledWith(mockQueued, 0);
+        expect(SpeculationEngine.getImpact).toHaveBeenCalledWith(mockQueued, 0);
         expect(reOrder).toBe(true);
       });
     });

--- a/src/lib/__tests__/SepculationEngine.test.ts
+++ b/src/lib/__tests__/SepculationEngine.test.ts
@@ -1,11 +1,130 @@
+import { LandRequest, LandRequestStatus, PullRequest } from '../../db';
+import { SepculationEngine } from '../SpeculationEngine';
+import { StateService } from '../StateService';
+
+jest.mock('../StateService');
+
 describe('SepculationEngine', () => {
-  test('getImpact > should return impact', async () => {});
-  test('positionInQueue > should return position in queue', async () => {});
-  test('getAvailableSlots > should return availabled free slots', async () => {});
+  let mockQueued: LandRequestStatus[] = [];
+  let mockRunning: LandRequestStatus[] = [];
+  let mockPullRequest: BB.PullRequest;
+  beforeEach(() => {
+    mockPullRequest = {
+      pullRequestId: 1,
+      authorAaid: '123',
+      title: 'Foo',
+      sourceBranch: 'test',
+      targetBranch: 'master',
+      commit: 'abc',
+    } as BB.PullRequest;
+    const pullRequest = new PullRequest({
+      prId: mockPullRequest.pullRequestId,
+      authorAaid: mockPullRequest.authorAaid,
+      title: mockPullRequest.title,
+      targetBranch: mockPullRequest.targetBranch,
+    });
+    mockQueued = [
+      new LandRequestStatus({
+        date: new Date(120),
+        id: '0',
+        isLatest: true,
+        request: new LandRequest({
+          created: new Date(120),
+          forCommit: 'abc',
+          id: '0',
+          triggererAaid: '123',
+          pullRequestId: 1,
+          pullRequest,
+        }),
+        requestId: '0',
+        state: 'queued',
+      }),
+      new LandRequestStatus({
+        date: new Date(120),
+        id: '1',
+        isLatest: true,
+        request: new LandRequest({
+          created: new Date(120),
+          forCommit: 'abc',
+          id: '1',
+          triggererAaid: '123',
+          pullRequestId: 1,
+          pullRequest,
+        }),
+        requestId: '0',
+        state: 'queued',
+      }),
+    ];
+
+    mockRunning = [
+      new LandRequestStatus({
+        date: new Date(120),
+        id: '0',
+        isLatest: true,
+        request: new LandRequest({
+          created: new Date(120),
+          forCommit: 'abc',
+          id: '0',
+          triggererAaid: '123',
+          pullRequestId: 1,
+          pullRequest,
+        }),
+        requestId: '0',
+        state: 'running',
+      }),
+      new LandRequestStatus({
+        date: new Date(120),
+        id: '1',
+        isLatest: true,
+        request: new LandRequest({
+          created: new Date(120),
+          forCommit: 'abc',
+          id: '1',
+          triggererAaid: '123',
+          pullRequestId: 1,
+          pullRequest,
+        }),
+        requestId: '0',
+        state: 'running',
+      }),
+    ];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('getAvailableSlots > should return availabled free slots', async () => {
+    jest.spyOn(StateService, 'getMaxConcurrentBuilds').mockResolvedValueOnce(3);
+    expect(await SepculationEngine.getAvailableSlots(mockRunning)).toBe(1);
+    expect(await SepculationEngine.getAvailableSlots([])).toBe(3);
+  });
+
+  test('positionInQueue > should return position in queue', async () => {
+    expect(await SepculationEngine.positionInQueue(mockQueued, mockQueued[1])).toBe(1);
+    expect(await SepculationEngine.positionInQueue(mockQueued, mockQueued[0])).toBe(0);
+  });
+
+  test('getImpact > should return impact', async () => {
+    const impact = await SepculationEngine.getImpact(mockQueued, 0);
+
+    // todo update after actual implementation of impact logic
+    expect(typeof impact.currentImpact).toBe('number');
+    expect(typeof impact.nextImpact).toBe('number');
+  });
 
   describe('reOrderRequest', () => {
-    test('should return false when the feature is turned off', async () => {});
+    test('should return false when the feature is turned off', async () => {
+      jest
+        .spyOn(StateService, 'getAdminSettings')
+        .mockResolvedValueOnce({ speculationEngineEnabled: false } as any);
+
+      expect(await SepculationEngine.reOrderRequest(mockRunning, mockQueued, mockQueued[0])).toBe(
+        false,
+      );
+    });
     test('should return false when number of free slots are less than 2', async () => {});
+    test('should return false when queue length is less than 2', async () => {});
     test('should return false when number of free slots are 2 and current request is 2nd in the queue', async () => {});
     test('should return false when number of free slots are 3 and current request is 3rd in the queue', async () => {});
     test('should return false when number of free slots are 2, current request is 1st in the queue and current request`s impact is less than next', async () => {});

--- a/src/lib/__tests__/StateService.test.ts
+++ b/src/lib/__tests__/StateService.test.ts
@@ -113,6 +113,7 @@ describe('StateService', () => {
 
     afterAll(() => {
       config.mergeSettings = oldMergeSettings;
+      config.speculationEngineEnabled = false;
     });
 
     const getMockMergeSettings = (mergeBlockingEnabled: boolean) =>
@@ -122,51 +123,65 @@ describe('StateService', () => {
         },
       } as any);
 
-    test('should return mergeBlockingEnabled as false when the feature is disabled via config (irrespective of the table data)', async () => {
+    test('should return mergeBlockingEnabled and speculationEngineEnabled as false when the feature is disabled via config (irrespective of the table data)', async () => {
       let settings = await StateService.getAdminSettings();
       expect(settings.mergeBlockingEnabled).toBe(false);
+      expect(settings.speculationEngineEnabled).toBe(false);
 
       config.mergeSettings = getMockMergeSettings(false);
       settings = await StateService.getAdminSettings();
       expect(settings.mergeBlockingEnabled).toBe(false);
+      expect(settings.speculationEngineEnabled).toBe(false);
 
       jest.spyOn(AdminSettings, 'findOne').mockResolvedValueOnce({
         mergeBlockingEnabled: true,
+        speculationEngineEnabled: true,
       } as any);
 
       settings = await StateService.getAdminSettings();
       expect(settings.mergeBlockingEnabled).toBe(false);
+      expect(settings.speculationEngineEnabled).toBe(false);
     });
 
-    test('should return mergeBlockingEnabled as false when the feature is enabled via config and disabled via UI', async () => {
+    test('should return mergeBlockingEnabled and speculationEngineEnabled as false when the feature is enabled via config and disabled via UI', async () => {
       config.mergeSettings = getMockMergeSettings(true);
+      config.speculationEngineEnabled = true;
       jest.spyOn(AdminSettings, 'findOne').mockResolvedValueOnce({
         mergeBlockingEnabled: false,
+        speculationEngineEnabled: false,
       } as any);
 
       const settings = await StateService.getAdminSettings();
       expect(settings.mergeBlockingEnabled).toBe(false);
+      expect(settings.speculationEngineEnabled).toBe(false);
     });
 
-    test('should return mergeBlockingEnabled as true when the feature is enabled via config and enabled via UI', async () => {
+    test('should return mergeBlockingEnabled and speculationEngineEnabled as true when the feature is enabled via config and enabled via UI', async () => {
       config.mergeSettings = getMockMergeSettings(true);
+      config.speculationEngineEnabled = true;
       jest.spyOn(AdminSettings, 'findOne').mockResolvedValueOnce({
         mergeBlockingEnabled: true,
+        speculationEngineEnabled: true,
       } as any);
 
       const settings = await StateService.getAdminSettings();
       expect(settings.mergeBlockingEnabled).toBe(true);
+      expect(settings.speculationEngineEnabled).toBe(true);
     });
   });
 
   test('updateAdminSettings > should update admin settings', async () => {
-    await StateService.updateAdminSettings({ mergeBlockingEnabled: true }, {
-      aaid: 'test-aaid',
-    } as any);
+    await StateService.updateAdminSettings(
+      { mergeBlockingEnabled: true, speculationEngineEnabled: true },
+      {
+        aaid: 'test-aaid',
+      } as any,
+    );
 
     expect(AdminSettings.create).toHaveBeenCalledWith({
       adminAaid: 'test-aaid',
       mergeBlockingEnabled: true,
+      speculationEngineEnabled: true,
     });
   });
 
@@ -180,7 +195,8 @@ describe('StateService', () => {
         pauseState: null,
         bannerMessageState: null,
         maxConcurrentBuilds: 2,
-        adminSettings: { mergeBlockingEnabled: false },
+        adminSettings: { mergeBlockingEnabled: false, speculationEngineEnabled: false },
+        config: { mergeSettings: {}, speculationEngineEnabled: false },
       }),
     );
   });

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -419,11 +419,19 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
       } else {
         request = await runner.enqueue(landRequestOptions);
       }
-      if (req.body.priority === 'low' && request) {
-        await request.decrementPriority();
-      } else if (req.body.priority === 'high' && request) {
-        await request.incrementPriority();
+
+      if (request) {
+        if (req.body.priority === 'low') {
+          await request.decrementPriority();
+        } else if (req.body.priority === 'high') {
+          await request.incrementPriority();
+        }
+
+        if (req.body.impact) {
+          await request.updateImpact(req.body.impact);
+        }
       }
+
       Logger.info('Land request created', {
         namespace: 'routes:api:create-landrequest',
         landRequestOptions,

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -168,12 +168,22 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
     requireAuth('admin'),
     wrap(async (req, res) => {
       const mergeBlockingEnabled = req?.body?.mergeBlockingEnabled;
-      Logger.verbose(`Updating mergeBlockingEnabled to ${mergeBlockingEnabled}`, {
-        namespace: 'routes:api:uupdate-admin-settings',
-      });
+      const speculationEngineEnabled = req?.body?.speculationEngineEnabled;
+      Logger.verbose(
+        `Updating mergeBlockingEnabled to ${mergeBlockingEnabled} and speculationEngineEnabled to ${speculationEngineEnabled}`,
+        {
+          namespace: 'routes:api:update-admin-settings',
+        },
+      );
 
-      if (typeof mergeBlockingEnabled == 'boolean') {
-        const success = await StateService.updateAdminSettings({ mergeBlockingEnabled }, req.user!);
+      if (
+        typeof mergeBlockingEnabled == 'boolean' &&
+        typeof speculationEngineEnabled == 'boolean'
+      ) {
+        const success = await StateService.updateAdminSettings(
+          { mergeBlockingEnabled, speculationEngineEnabled },
+          req.user!,
+        );
         if (success) {
           return res.status(200).json({ success: true });
         } else {
@@ -181,7 +191,9 @@ export function apiRoutes(runner: Runner, client: BitbucketClient, config: Confi
         }
       }
 
-      return res.status(400).json({ err: 'req.body.mergeBlockingEnabled should be boolean' });
+      return res.status(400).json({
+        err: 'req.body.mergeBlockingEnabled and req.body.speculationEngineEnabled should be boolean',
+      });
     }),
   );
 

--- a/src/routes/api/test.ts
+++ b/src/routes/api/test.ts
@@ -191,21 +191,51 @@ describe('API Routes', () => {
     });
     it('should fail with status 400 if mergeBlockingEnabled is not supplied', async () => {
       expect(mockResponse.status).not.toHaveBeenCalled();
-      await updateAdminSettingsHandler({ body: {} }, mockExpress.response, () => {});
+      await updateAdminSettingsHandler(
+        {
+          body: {
+            speculationEngineEnabled: true,
+          },
+        },
+        mockExpress.response,
+        () => {},
+      );
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockResponse.json).toHaveBeenCalledWith(
-        expect.objectContaining({ err: 'req.body.mergeBlockingEnabled should be boolean' }),
+        expect.objectContaining({
+          err: 'req.body.mergeBlockingEnabled and req.body.speculationEngineEnabled should be boolean',
+        }),
+      );
+    });
+
+    it('should fail with status 400 if speculationEngineEnabled is not supplied', async () => {
+      expect(mockResponse.status).not.toHaveBeenCalled();
+      await updateAdminSettingsHandler(
+        {
+          body: {
+            mergeBlockingEnabled: true,
+          },
+        },
+        mockExpress.response,
+        () => {},
+      );
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: 'req.body.mergeBlockingEnabled and req.body.speculationEngineEnabled should be boolean',
+        }),
       );
     });
 
     it.each([[null], ['true']])(
-      'should fail with status 400 if mergeBlockingEnabled %s is not boolean',
+      'should fail with status 400 if mergeBlockingEnabled and speculationEngineEnabled %s is not boolean',
       async (input) => {
         expect(mockResponse.status).not.toHaveBeenCalled();
         await updateAdminSettingsHandler(
           {
             body: {
               mergeBlockingEnabled: input,
+              speculationEngineEnabled: input,
             },
           },
           mockExpress.response,
@@ -214,7 +244,7 @@ describe('API Routes', () => {
         expect(mockResponse.status).toHaveBeenCalledWith(400);
         expect(mockResponse.json).toHaveBeenCalledWith(
           expect.objectContaining({
-            err: 'req.body.mergeBlockingEnabled should be boolean',
+            err: 'req.body.mergeBlockingEnabled and req.body.speculationEngineEnabled should be boolean',
           }),
         );
       },
@@ -228,6 +258,7 @@ describe('API Routes', () => {
         {
           body: {
             mergeBlockingEnabled: true,
+            speculationEngineEnabled: true,
           },
           user: { aaid: 'mock-user-aaid' },
         },
@@ -235,7 +266,7 @@ describe('API Routes', () => {
         () => {},
       );
       expect(StateService.updateAdminSettings).toHaveBeenCalledWith(
-        { mergeBlockingEnabled: true },
+        { mergeBlockingEnabled: true, speculationEngineEnabled: true },
         {
           aaid: 'mock-user-aaid',
         },
@@ -252,6 +283,7 @@ describe('API Routes', () => {
         {
           body: {
             mergeBlockingEnabled: true,
+            speculationEngineEnabled: true,
           },
           user: { aaid: 'mock-user-aaid' },
         },
@@ -259,7 +291,7 @@ describe('API Routes', () => {
         () => {},
       );
       expect(StateService.updateAdminSettings).toHaveBeenCalledWith(
-        { mergeBlockingEnabled: true },
+        { mergeBlockingEnabled: true, speculationEngineEnabled: true },
         {
           aaid: 'mock-user-aaid',
         },

--- a/src/routes/bitbucket/proxy/index.ts
+++ b/src/routes/bitbucket/proxy/index.ts
@@ -205,9 +205,12 @@ export function proxyRoutes(runner: Runner, client: BitbucketClient) {
             landRequest,
           });
         }
-        // TODO: add condition to check if the speculation engine is enabled from the admin settings
-        const impact = await client.bitbucket.getPRImpact(commit);
-        request.updateImpact(impact);
+
+        const { speculationEngineEnabled } = await StateService.getAdminSettings();
+        if (speculationEngineEnabled) {
+          const impact = await client.bitbucket.getPRImpact(commit);
+          request.updateImpact(impact);
+        }
       }
       res.sendStatus(200);
       runner.next();

--- a/src/static/current-state/components/tabs/index.tsx
+++ b/src/static/current-state/components/tabs/index.tsx
@@ -92,7 +92,7 @@ export type TabsProps = {
   permissionsMessage: string;
   priorityBranchList: IPriorityBranch[];
   adminSettings: IAdminSettings;
-  config: { mergeSettings?: MergeSettings };
+  config: { mergeSettings?: MergeSettings; speculationEngineEnabled: boolean };
   refreshData: () => void;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,7 @@ export type Config = {
   eventListeners?: EventListener[];
   easterEgg?: any;
   mergeSettings?: MergeSettings;
+  speculationEngineEnabled: boolean;
 };
 
 export type MergeSettings = {
@@ -133,7 +134,7 @@ export type State = {
   daysSinceLastFailure: number;
   priorityBranchList: IPriorityBranch[];
   adminSettings: IAdminSettings;
-  config: { mergeSettings?: MergeSettings };
+  config: { mergeSettings?: MergeSettings; speculationEngineEnabled: boolean };
 };
 
 export type RunnerState = State & {

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -65,7 +65,7 @@ declare interface IPriorityBranch {
 declare interface IAdminSettings {
   adminAaid?: string;
   mergeBlockingEnabled: boolean;
-  speculationEngineEnabled?: boolean;
+  speculationEngineEnabled: boolean;
 }
 
 declare type IStatusState =

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -65,20 +65,23 @@ declare interface IPriorityBranch {
 declare interface IAdminSettings {
   adminAaid?: string;
   mergeBlockingEnabled: boolean;
+  speculationEngineEnabled?: boolean;
 }
+
+declare type IStatusState =
+  | 'will-queue-when-ready'
+  | 'queued'
+  | 'running'
+  | 'awaiting-merge'
+  | 'merging'
+  | 'success'
+  | 'fail'
+  | 'aborted';
 
 declare interface IStatusUpdate {
   id: string;
   date: Date;
-  state:
-    | 'will-queue-when-ready'
-    | 'queued'
-    | 'running'
-    | 'awaiting-merge'
-    | 'merging'
-    | 'success'
-    | 'fail'
-    | 'aborted';
+  state: IStatusState;
   reason: string | null;
   requestId: string;
   isLatest: boolean;


### PR DESCRIPTION
Added speculation engine to re-order PR based on impact. It is target repos's responsibility to provide impact of each PR using BBP build statuses. The engine attempts to re-order a land-request if

1. speculationEngineEnabled feature is enabled
2. available free running slots are at least 2
3. Position of current requests in the queue compared to number of slots.
            for example if 2 slots are available consider re-ordering 1st request from the queue
                        if 3 slots are available consider re-ordering 1st and 2nd request from the queue
4. Size of queue is more than 1
 5. Impact of the current request compared to the next (available slots - 1) number of requests in queue

The feature can be live toggled using below admin controls.
<img width="777" alt="image" src="https://user-images.githubusercontent.com/25855928/223591984-419858ef-c1e9-4436-adba-7d63bf9f8192.png">

Impact retrieved and integrated for re-ordering.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/25855928/223604844-36ab0f2d-c383-46fb-878f-65ce3984217d.png">

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/25855928/223607697-e5f87e0c-8bf9-43c5-b5a8-9e2fcb46c3a9.png">


Impact displayed on the UI
<img width="958" alt="image" src="https://user-images.githubusercontent.com/25855928/223607422-3da9d197-617d-4a7d-8e6d-6290b8269dff.png">
