### PR TITLE
Fix issues when there are too many PR dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Landkid emits events for metrics integrations:
 - 'PULL_REQUEST.QUEUE_WHEN_ABLE.SUCCESS'
 - 'PULL_REQUEST.QUEUE_WHEN_ABLE.FAIL'
 - 'LAND_REQUEST.STATUS.CHANGED'
+- 'QUEUE.MAX_DEPENDENCIES'
 
 Add event listeners to `config.js` to use these events.
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -72,7 +72,8 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   pullRequest: PullRequest;
 
   @AllowNull(true)
-  @Column(Sequelize.STRING)
+  // Handle up to 25 dependencies ((36 char request IDs + 1 comma separator) * 25) = 925
+  @Column(Sequelize.STRING({ length: 1000 }))
   dependsOn: string;
 
   @AllowNull(true)

--- a/src/db/migrations/09__updateDependsOnColumn.ts
+++ b/src/db/migrations/09__updateDependsOnColumn.ts
@@ -1,0 +1,16 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  up: async function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.changeColumn('LandRequest', 'dependsOn', {
+      type: Sequelize.STRING({ length: 1000 }), // set the maximum length to 1000
+      allowNull: true,
+    });
+  },
+  down: async function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.changeColumn('LandRequest', 'dependsOn', {
+      type: Sequelize.STRING(), // set the maximum length back to default 255
+      allowNull: true,
+    });
+  },
+};

--- a/src/lib/__tests__/Runner.test.ts
+++ b/src/lib/__tests__/Runner.test.ts
@@ -438,6 +438,24 @@ describe('Runner', () => {
         'Build timeout period breached',
       );
     });
+
+    test('should fail land request if build ID is missing', async () => {
+      //running state is beyond the timeout period of 2 hours
+      const mockLandRequestStatus = getLandRequestStatus(new Date());
+      mockLandRequestStatus.request.buildId = null as any;
+
+      mockQueue.getRunning = jest.fn(async () => [mockLandRequestStatus]);
+
+      expectLoggerError(loggerSpies.error);
+      expect(mockLandRequestStatus.request.setStatus).not.toHaveBeenCalled();
+      await runner.checkRunningLandRequests();
+
+      expect(mockLandRequestStatus.request.setStatus).toHaveBeenCalledTimes(1);
+      expect(mockLandRequestStatus.request.setStatus).toHaveBeenCalledWith(
+        'fail',
+        'Missing buildId',
+      );
+    });
   });
 
   describe('areMaxConcurrentBuildsRunning', () => {

--- a/src/lib/__tests__/Runner.test.ts
+++ b/src/lib/__tests__/Runner.test.ts
@@ -52,6 +52,9 @@ function suppressAndSpyLogging() {
   const warn = jest.spyOn(Logger, 'warn').mockImplementation(() => {
     return undefined as any;
   });
+  const verbose = jest.spyOn(Logger, 'verbose').mockImplementation(() => {
+    return undefined as any;
+  });
   // Log the actual error from catch-all error handlers and throw to ensure we explicitly handle
   // error cases in tests
   const origLoggerError = Logger.error;
@@ -60,13 +63,14 @@ function suppressAndSpyLogging() {
     const err = payload.err || msg;
     throw err;
   }) as any);
-  return { info, warn, error };
+  return { info, warn, error, verbose };
 }
 
 describe('Runner', () => {
   let runner: Runner;
   let mockQueue: LandRequestQueue;
   let loggerSpies: {
+    verbose: jest.SpyInstance<any, any>;
     info: jest.SpyInstance<any, any>;
     warn: jest.SpyInstance<any, any>;
     error: jest.SpyInstance<any, any>;
@@ -495,6 +499,79 @@ describe('Runner', () => {
       expect(runner.areMaxConcurrentBuildsRunning).toHaveBeenCalledWith([]);
       expect(response).toBe(false);
       expect(request.setStatus).not.toHaveBeenCalled();
+    });
+
+    test('should return false if total number of running, awaiting merge & merge requests exceed the max number of land dependencies (25)', async () => {
+      const request = new LandRequest({
+        created: new Date(123),
+        forCommit: 'abc',
+        id: '1',
+        triggererAaid: '123',
+        pullRequestId: 1,
+        pullRequest: new PullRequest({
+          prId: mockPullRequest.pullRequestId,
+          authorAaid: mockPullRequest.authorAaid,
+          title: mockPullRequest.title,
+          targetBranch: mockPullRequest.targetBranch,
+        }),
+      });
+      const status = new LandRequestStatus({
+        date: new Date(123),
+        id: '1',
+        isLatest: true,
+        request,
+        requestId: '1',
+        state: 'queued',
+      });
+
+      // Cannot run any more when 26 total running PRs
+      jest.spyOn(runner, 'getRunning').mockResolvedValueOnce(
+        Array.from({ length: 26 }).map(() => ({
+          request: { pullRequest: { targetBranch: mockPullRequest.targetBranch } },
+        })) as any,
+      );
+      const response = await runner.moveFromQueueToRunning(status, new Date());
+      expect(response).toBe(false);
+      expect(request.setStatus).not.toHaveBeenCalled();
+      expect(loggerSpies.verbose).toHaveBeenCalledWith(
+        'No concurrent build slots left',
+        expect.anything(),
+      );
+
+      // Can run when there are 25 total running PRs (since it is less than 26)
+      jest.clearAllMocks();
+      jest.spyOn(runner, 'getRunning').mockResolvedValueOnce(
+        Array.from({ length: 25 }).map(
+          (v, i) =>
+            new LandRequestStatus({
+              date: new Date(i + 2),
+              id: `${i + 2}`,
+              isLatest: true,
+              requestId: `${i + 2}`,
+              state: 'awaiting-merge',
+              request: new LandRequest({
+                created: new Date(i + 2),
+                forCommit: 'abc',
+                id: `${i + 2}`,
+                triggererAaid: '123',
+                pullRequestId: i + 2,
+                pullRequest: new PullRequest({
+                  prId: i + 2,
+                  authorAaid: '123',
+                  title: 'Title',
+                  targetBranch: mockPullRequest.targetBranch,
+                }),
+              }),
+            }),
+        ),
+      );
+      const responseTwo = await runner.moveFromQueueToRunning(status, new Date());
+      expect(responseTwo).toBe(true);
+      expect(request.setStatus).toHaveBeenCalledTimes(1);
+      expect(request.setStatus).toHaveBeenCalledWith(
+        'running',
+        'Started with PR dependencies: 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26',
+      );
     });
 
     test('should successfully transition land request from queued to running if all checks pass', async () => {


### PR DESCRIPTION
PRs that transition to running with more than 7 dependencies (including both running and awaiting-merge) will cause a `SequelizeDatabaseError: value too long for type character varying(255)` sequelize error.
This is caused by  dependsOn column of a landRequest table exceeding the max string length of 255 characters. The dependsOn column contains each dependency landRequest ID (36 characters) separated by commas (1 column). So only `Math.floor(255/36) = 6` dependencies can fit in the column. This means 2 running requests + 4 PRs awaiting merge.

When the sequelize error occurs, neither the dependsOn or buildId fields are attached to the land request after its status is set to running. This then results in the request eventually timing out after 2 hours due to our landkid build timeout handling that we added recently.

I've added the following to rectify this issue:

* Update the max length of the dependsOn column from 255 chars to 1000 chars
* Include a hard limit of dependencies of 25 so that we do not exceed the 1000 char limit
* Handle transitions to running more robustly by catching these types of errors and setting the status to failed to remove them from the queue immediately.
* Add an additional check for buildId in our timeout check that will fail the request if no buildId is found