### PR TITLE
MONO-521 Added landBuildTimeoutTime to instance configuration

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -40,6 +40,7 @@ module.exports = {
     requireClosedTasks: true,
     requireGreenBuild: false,
     allowLandWhenAble: true,
+    landBuildTimeoutTime: 1000 * 60 * 60 * 2, // 2 hours
     /** What is provided to a custom rule:
      *  {
      *    pullRequest: BB.PullRequest -- see /src/bitbucket/types.d.ts

--- a/src/bitbucket/BitbucketAPI.ts
+++ b/src/bitbucket/BitbucketAPI.ts
@@ -42,7 +42,7 @@ export class BitbucketAPI {
     options: MergeOptions = {},
   ): Promise<MergePullRequestResult> => {
     const {
-      id: landRequestId,
+      requestId: landRequestId,
       request: {
         pullRequestId,
         pullRequest: { targetBranch },

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -688,11 +688,15 @@ export class Runner {
                 await landRequest.setStatus('fail', 'Missing buildId');
               }
               const timeElapsed = Date.now() - landRequestStatus.date.getTime();
+              const landBuildTimeoutTime =
+                this.config.prSettings.landBuildTimeoutTime || LAND_BUILD_TIMEOUT_TIME;
 
-              if (timeElapsed > LAND_BUILD_TIMEOUT_TIME) {
+              if (timeElapsed > landBuildTimeoutTime) {
                 Logger.warn('Failing running land request as timeout period is breached', {
                   pullRequestId: landRequest.pullRequestId,
                   landRequestId: landRequest.id,
+                  landBuildTimeoutTime,
+                  timeElapsed,
                   namespace: 'lib:runner:checkRunningLandRequests',
                 });
                 await landRequest.setStatus('fail', 'Build timeout period breached');

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type PullRequestSettings = {
   allowLandWhenAble: boolean;
   customChecks?: CustomRule[];
   customWarnings?: CustomRule[];
+  landBuildTimeoutTime?: number;
 };
 
 export type ApprovalChecks = {


### PR DESCRIPTION
Added landBuildTimeoutTime to system configuration. So, each instance can update the timeout based on their CI requirements. It defaults to 120 mins if not configured.