### PR TITLE
Fix/dependencies bug

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -77,6 +77,10 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
   dependsOn: string;
 
   @AllowNull(true)
+  @Column(Sequelize.STRING({ length: 1000 }))
+  dependsOnPrIds: string;
+
+  @AllowNull(true)
   @Default(0)
   @Column(Sequelize.INTEGER)
   priority: number;
@@ -160,6 +164,7 @@ export class LandRequest extends Model<LandRequest> implements ILandRequest {
       stateDuration: prevStatus ? Date.now() - prevStatus.date.getTime() : null,
       durationSinceQueued: queuedDate ? Date.now() - queuedDate.getTime() : null,
       dependsOn: this.dependsOn,
+      dependsOnPrIds: this.dependsOnPrIds,
     });
     return true;
   };

--- a/src/db/migrations/11__dependsOnPrIds.ts
+++ b/src/db/migrations/11__dependsOnPrIds.ts
@@ -2,13 +2,13 @@ import { QueryInterface, DataTypes } from 'sequelize';
 
 export default {
   up: async function (query: QueryInterface, Sequelize: DataTypes) {
-    return query.changeColumn('LandRequest', 'dependsOnPrIds', {
+    return query.addColumn('LandRequest', 'dependsOnPrIds', {
       type: Sequelize.STRING({ length: 1000 }), // set the maximum length to 1000
       allowNull: true,
     });
   },
   down: async function (query: QueryInterface, Sequelize: DataTypes) {
-    return query.changeColumn('LandRequest', 'dependsOnPrIds', {
+    return query.addColumn('LandRequest', 'dependsOnPrIds', {
       type: Sequelize.STRING(), // set the maximum length back to default 255
       allowNull: true,
     });

--- a/src/db/migrations/11__dependsOnPrIds.ts
+++ b/src/db/migrations/11__dependsOnPrIds.ts
@@ -1,0 +1,16 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export default {
+  up: async function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.changeColumn('LandRequest', 'dependsOnPrIds', {
+      type: Sequelize.STRING({ length: 1000 }), // set the maximum length to 1000
+      allowNull: true,
+    });
+  },
+  down: async function (query: QueryInterface, Sequelize: DataTypes) {
+    return query.changeColumn('LandRequest', 'dependsOnPrIds', {
+      type: Sequelize.STRING(), // set the maximum length back to default 255
+      allowNull: true,
+    });
+  },
+};

--- a/src/db/migrations/11__dependsOnPrIds.ts
+++ b/src/db/migrations/11__dependsOnPrIds.ts
@@ -7,10 +7,7 @@ export default {
       allowNull: true,
     });
   },
-  down: async function (query: QueryInterface, Sequelize: DataTypes) {
-    return query.addColumn('LandRequest', 'dependsOnPrIds', {
-      type: Sequelize.STRING(), // set the maximum length back to default 255
-      allowNull: true,
-    });
+  async down() {
+    throw new Error('NO DROP FUNCTION FOR THIS MIGRATION');
   },
 };

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -164,7 +164,8 @@ export class Runner {
 
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
-    const dependsOnStr = dependencies.map((queueItem) => queueItem.request.pullRequestId).join(',');
+    const dependsOnStr = dependencies.map((queueItem) => queueItem.request.id).join(',');
+
     Logger.info('Attempting to move from queued to running', {
       namespace: 'lib:runner:moveFromQueueToRunning',
       landRequestId: landRequest.id,
@@ -899,7 +900,7 @@ export class Runner {
     return queue.filter(
       (status) =>
         status.state === 'awaiting-merge' &&
-        status.request.dependsOn.split(',').includes(String(currentStatus.request.pullRequestId)),
+        status.request.dependsOn.split(',').includes(String(currentStatus.request.id)),
     );
   }
 }

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -164,8 +164,7 @@ export class Runner {
 
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
-    const dependsOnStr = dependencies.map((queueItem) => queueItem.request.id).join(',');
-
+    const dependsOnStr = dependencies.map((queueItem) => queueItem.request.pullRequestId).join(',');
     Logger.info('Attempting to move from queued to running', {
       namespace: 'lib:runner:moveFromQueueToRunning',
       landRequestId: landRequest.id,
@@ -900,7 +899,7 @@ export class Runner {
     return queue.filter(
       (status) =>
         status.state === 'awaiting-merge' &&
-        status.request.dependsOn.split(',').includes(String(currentStatus.request.id)),
+        status.request.dependsOn.split(',').includes(String(currentStatus.request.pullRequestId)),
     );
   }
 }

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -209,7 +209,6 @@ export class Runner {
       landRequest.buildId = buildId;
       landRequest.dependsOn = dependsOnStr;
       landRequest.dependsOnPrIds = dependsOnPrIds.toString();
-      console.log('dependsonPrIds: ', landRequest.dependsOnPrIds);
       await landRequest.setStatus('running', depPrsStr);
 
       newLandRequest = await landRequest.save();

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -165,7 +165,7 @@ export class Runner {
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
     const dependsOnStr = dependencies.map((queueItem) => queueItem.request.id).join(',');
-
+    const dependsOnPrIds = dependencies.map((queueItem) => '#' + queueItem.request.pullRequestId);
     Logger.info('Attempting to move from queued to running', {
       namespace: 'lib:runner:moveFromQueueToRunning',
       landRequestId: landRequest.id,
@@ -208,10 +208,7 @@ export class Runner {
       // Todo: these should really be functions on landRequest
       landRequest.buildId = buildId;
       landRequest.dependsOn = dependsOnStr;
-      const getDependsOnPrs = await landRequest.getDependencies();
-      landRequest.dependsOnPrIds = getDependsOnPrs
-        .map((dependency) => dependency.pullRequestId)
-        .toString();
+      landRequest.dependsOnPrIds = dependsOnPrIds.toString();
       console.log('dependsonPrIds: ', landRequest.dependsOnPrIds);
       await landRequest.setStatus('running', depPrsStr);
 

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -165,7 +165,7 @@ export class Runner {
     // Dependencies will be all `running` or `awaiting-merge` builds that target the same branch
     // as yourself
     const dependsOnStr = dependencies.map((queueItem) => queueItem.request.id).join(',');
-    const dependsOnPrIds = dependencies.map((queueItem) => '#' + queueItem.request.pullRequestId);
+    const dependsOnPrIds = dependencies.map((queueItem) => queueItem.request.pullRequestId);
     Logger.info('Attempting to move from queued to running', {
       namespace: 'lib:runner:moveFromQueueToRunning',
       landRequestId: landRequest.id,

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -208,6 +208,11 @@ export class Runner {
       // Todo: these should really be functions on landRequest
       landRequest.buildId = buildId;
       landRequest.dependsOn = dependsOnStr;
+      const getDependsOnPrs = await landRequest.getDependencies();
+      landRequest.dependsOnPrIds = getDependsOnPrs
+        .map((dependency) => dependency.pullRequestId)
+        .toString();
+      console.log('dependsonPrIds: ', landRequest.dependsOnPrIds);
       await landRequest.setStatus('running', depPrsStr);
 
       newLandRequest = await landRequest.save();

--- a/src/lib/__tests__/Runner.test.ts
+++ b/src/lib/__tests__/Runner.test.ts
@@ -663,7 +663,7 @@ describe('Runner', () => {
       const response = await runner.moveFromQueueToRunning(status, new Date());
       expect(response).toBe(true);
       expect(request.setStatus).toHaveBeenCalledTimes(1);
-      expect(request.dependsOnPrIds).toBe('#2,#3,#4');
+      expect(request.dependsOnPrIds).toBe('2,3,4');
     });
     test('should successfully transition land request from queued to running if all checks pass', async () => {
       const request = new LandRequest({

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -367,7 +367,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
   };
 
   render() {
-    const { bitbucketBaseUrl, queue } = this.props;
+    const { bitbucketBaseUrl } = this.props;
     const { status } = this.state;
     const {
       request: { dependsOn, pullRequestId, pullRequest },
@@ -375,19 +375,8 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
 
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
-    const dependsOnPRs: string[] = [];
-    if (dependsOn && queue) {
-      dependsOn.split(',').forEach((depId) => {
-        const depItem = queue.find((item) => item.requestId === depId);
-        if (!depItem) {
-          console.error(`Cannot find dependency PR with request id ${status.requestId}`);
-          dependsOnPRs.push('??');
-        } else {
-          dependsOnPRs.push(`#${depItem.request.pullRequestId}`);
-        }
-      });
-    }
-
+    const dependsOnPRs: string[] = dependsOn?.split(',') ?? [];
+    console.log('dependsOnPrs: ', dependsOnPRs);
     return (
       <div className={`${queueItemStyles} queue-item`}>
         <div className="queue-item__title">

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -376,8 +376,9 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
 
-    const dependsOnPRs: string[] = dependsOnPrIds ? dependsOnPrIds?.split(',') : [];
-
+    const dependsOnPRs: string[] = dependsOnPrIds
+      ? dependsOnPrIds.split(',').map((dep) => '#' + dep)
+      : [];
     return (
       <div className={`${queueItemStyles} queue-item`}>
         <div className="queue-item__title">

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -367,26 +367,20 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
   };
 
   render() {
-    const { bitbucketBaseUrl, queue } = this.props;
+    const { bitbucketBaseUrl } = this.props;
     const { status } = this.state;
     const {
-      request: { dependsOn, pullRequestId, pullRequest },
+      request: { dependsOnPrIds, pullRequestId, pullRequest },
     } = status;
 
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
-    const dependsOnPRs: string[] = [];
-    if (dependsOn && queue) {
-      dependsOn.split(',').forEach((depId) => {
-        const depItem = queue.find((item) => item.requestId === depId);
-        if (!depItem) {
-          console.error(`Cannot find dependency PR with request id ${status.requestId}`);
-          dependsOnPRs.push('??');
-        } else {
-          dependsOnPRs.push(`#${depItem.request.pullRequestId}`);
-        }
-      });
-    }
+
+    const dependsOnPRs: string[] = dependsOnPrIds
+      ? dependsOnPrIds?.split(',').map((dep) => '#' + dep)
+      : [];
+
+    console.log(dependsOnPRs);
 
     return (
       <div className={`${queueItemStyles} queue-item`}>

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -367,7 +367,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
   };
 
   render() {
-    const { bitbucketBaseUrl } = this.props;
+    const { bitbucketBaseUrl, queue } = this.props;
     const { status } = this.state;
     const {
       request: { dependsOn, pullRequestId, pullRequest },
@@ -375,8 +375,19 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
 
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
-    const dependsOnPRs: string[] = dependsOn?.split(',') ?? [];
-    console.log('dependsOnPrs: ', dependsOnPRs);
+    const dependsOnPRs: string[] = [];
+    if (dependsOn && queue) {
+      dependsOn.split(',').forEach((depId) => {
+        const depItem = queue.find((item) => item.requestId === depId);
+        if (!depItem) {
+          console.error(`Cannot find dependency PR with request id ${status.requestId}`);
+          dependsOnPRs.push('??');
+        } else {
+          dependsOnPRs.push(`#${depItem.request.pullRequestId}`);
+        }
+      });
+    }
+
     return (
       <div className={`${queueItemStyles} queue-item`}>
         <div className="queue-item__title">

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -376,9 +376,7 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
     const buildId = status.request.buildId;
     const buildUrl = buildId ? buildUrlFromId(bitbucketBaseUrl, buildId) : '#';
 
-    const dependsOnPRs: string[] = dependsOnPrIds
-      ? dependsOnPrIds?.split(',').map((dep) => '#' + dep)
-      : [];
+    const dependsOnPRs: string[] = dependsOnPrIds ? dependsOnPrIds?.split(',') : [];
 
     console.log(dependsOnPRs);
 

--- a/src/static/current-state/components/QueueItem.tsx
+++ b/src/static/current-state/components/QueueItem.tsx
@@ -378,8 +378,6 @@ export class QueueItem extends React.Component<QueueItemProps, QueueItemState> {
 
     const dependsOnPRs: string[] = dependsOnPrIds ? dependsOnPrIds?.split(',') : [];
 
-    console.log(dependsOnPRs);
-
     return (
       <div className={`${queueItemStyles} queue-item`}>
         <div className="queue-item__title">

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -26,6 +26,7 @@ declare interface ILandRequest {
   created: Date;
   pullRequest: IPullRequest;
   dependsOn: string | null;
+  dependsOnPrIds: string | null;
   priority: number | null;
   impact: number | null;
 }


### PR DESCRIPTION
This PR fixes the "??" bug which was introduced after the new merge queue was implemented. When the dependent builds are placed in the merging queue, the dependent builds are no longer in the queue. The logic to find the dependent PRs cannot find these request ids, so it defaults to "??"

Changes in this PR:
- Added dependsOnPrIds column to the LandRequest table 
- Stores prIds as dependencies in `moveFromQueueToRunning`  
- Renders dependsOnPrIds in `QueueItem` component

Tested in staging ✅ 
![image](https://github.com/atlassian/landkid/assets/19305535/60621143-46bc-4b03-9b64-50a120bf4fb3)