### PR TITLE
[dev] Fail all dependents in one go.

### DIFF
--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -99,8 +99,6 @@ export class Runner {
         namespace: 'lib:runner:moveFromQueueToRunning',
         landRequestId: landRequest.id,
         pullRequestId: landRequest.pullRequestId,
-        // landRequestStatus,
-        // runningTargetingSameBranch,
         lockId,
       });
       return false;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -476,13 +476,13 @@ export class Runner {
   // So, multiple free slots are available in one go for the speculation engine to process.
   failAllDependents = async (
     currentLandRequestStatus: LandRequestStatus,
-    currentRequestState: IStatusState,
-    currentRequestReason: string,
+    state: IStatusState,
+    reason: string,
   ) => {
     await withLock(
       'status-transition',
       async (lockId: Date) => {
-        await currentLandRequestStatus.request.setStatus(currentRequestState, currentRequestReason);
+        await currentLandRequestStatus.request.setStatus(state, reason);
         const running = await this.getRunning();
         const dependents = Runner.getDependents(running, currentLandRequestStatus);
 
@@ -497,7 +497,6 @@ export class Runner {
         }
       },
       undefined,
-      100,
     );
   };
 

--- a/src/lib/__tests__/Runner.test.ts
+++ b/src/lib/__tests__/Runner.test.ts
@@ -919,6 +919,7 @@ describe('Runner', () => {
     let request: LandRequest;
     let nextSpy: jest.SpyInstance<any>;
     let runningStatuses: LandRequestStatus[];
+    let dependentRequest: LandRequest;
     beforeEach(() => {
       const pullRequest = new PullRequest({
         prId: mockPullRequest.pullRequestId,
@@ -926,22 +927,33 @@ describe('Runner', () => {
         title: mockPullRequest.title,
         targetBranch: mockPullRequest.targetBranch,
       });
-      request = new LandRequest({
+      const requestParam = {
         buildId: 1234,
         created: new Date(120),
         forCommit: 'abc',
-        id: '0',
+        id: '01',
         triggererAaid: '123',
         pullRequestId: 1,
         pullRequest,
-      });
+        dependsOn: '',
+      };
+      request = new LandRequest(requestParam);
+      dependentRequest = new LandRequest({ ...requestParam, buildId: 4567, dependsOn: '01' });
       runningStatuses = [
         new LandRequestStatus({
           date: new Date(120),
-          id: '0',
+          id: '01',
           isLatest: true,
           request,
-          requestId: '0',
+          requestId: '01',
+          state: 'running',
+        }),
+        new LandRequestStatus({
+          date: new Date(120),
+          id: '02',
+          isLatest: true,
+          request: dependentRequest,
+          requestId: '02',
           state: 'running',
         }),
       ];
@@ -970,6 +982,16 @@ describe('Runner', () => {
         buildStatus: 'FAILED',
       });
       expect(request.setStatus).toHaveBeenCalledWith('fail', 'Landkid build failed');
+      expect(dependentRequest.setStatus).toHaveBeenNthCalledWith(
+        1,
+        'fail',
+        'Failed due to failed dependency builds: 1',
+      );
+      expect(dependentRequest.setStatus).toHaveBeenNthCalledWith(
+        2,
+        'queued',
+        'Queued by undefined',
+      );
       expect(nextSpy).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Updated the BBC webhook callback utility to fail all dependent requests simultaneously. This would create more scenarios where multiple running slots are freed up, eventually causing the speculation engine to kick in for re-ordering pull requests based on impact.